### PR TITLE
adding font smoothing option

### DIFF
--- a/src/protocols/rdp/client.c
+++ b/src/protocols/rdp/client.c
@@ -101,6 +101,7 @@ const char* GUAC_CLIENT_ARGS[] = {
     "remote-app-dir",
     "remote-app-args",
     "static-channels",
+    "enable-font-smoothing",
     NULL
 };
 
@@ -129,6 +130,7 @@ enum RDP_ARGS_IDX {
     IDX_REMOTE_APP_DIR,
     IDX_REMOTE_APP_ARGS,
     IDX_STATIC_CHANNELS,
+    IDX_ENABLE_FONT_SMOOTHING,
     RDP_ARGS_COUNT
 };
 
@@ -650,6 +652,10 @@ int guac_client_init(guac_client* client, int argc, char** argv) {
     /* Drive enable/disable */
     guac_client_data->settings.drive_enabled =
         (strcmp(argv[IDX_ENABLE_DRIVE], "true") == 0);
+        
+    /* Font smoothing enable/disable */
+    guac_client_data->settings.font_smoothing_enabled = 
+        (strcmp(argv[IDX_ENABLE_FONT_SMOOTHING], "true") == 0);
 
     guac_client_data->settings.drive_path = strdup(argv[IDX_DRIVE_PATH]);
 

--- a/src/protocols/rdp/rdp_settings.c
+++ b/src/protocols/rdp/rdp_settings.c
@@ -270,5 +270,14 @@ void guac_rdp_push_settings(guac_rdp_settings* guac_settings, freerdp* rdp) {
     rdp_settings->OrderSupport[NEG_ELLIPSE_CB_INDEX] = FALSE;
 #endif
 
+#ifdef LEGACY_RDPSETTINGS
+    if (guac_settings->font_smoothing_enabled) {
+      rdp_settings->performance_flags |= PERF_ENABLE_FONT_SMOOTHING;
+    }
+#else
+    if (guac_settings->font_smoothing_enabled) {
+      rdp_settings->PerformanceFlags |= PERF_ENABLE_FONT_SMOOTHING;
+    }
+#endif
 }
 

--- a/src/protocols/rdp/rdp_settings.h
+++ b/src/protocols/rdp/rdp_settings.h
@@ -123,6 +123,11 @@ typedef struct guac_rdp_settings {
     int height;
 
     /**
+     * Whether or not font-smoothing is enabled.
+     */
+    int font_smoothing_enabled;
+    
+    /**
      * Whether audio is enabled.
      */
     int audio_enabled;


### PR DESCRIPTION
This allows the guacd client to send up the enable-font-smoothing argument as part of the connect string to turn on font smoothing for the requested RDP session. This will only work if the remote terminal server has enabled ClearType fonts. It also has a negative impact on performance and therefore defaults to off.