### PR TITLE
GUAC-936: Use initial resolution for all future resizing of display.

### DIFF
--- a/src/protocols/rdp/Makefile.am
+++ b/src/protocols/rdp/Makefile.am
@@ -43,6 +43,7 @@ libguac_client_rdp_la_SOURCES = \
 	rdp_settings.c              \
 	rdp_stream.c                \
 	rdp_svc.c                   \
+	resolution.c                \
 	unicode.c
 
 guacsvc_sources =          \
@@ -95,6 +96,7 @@ noinst_HEADERS =                             \
 	rdp_status.h                             \
 	rdp_stream.h                             \
 	rdp_svc.h                                \
+	resolution.h                             \
 	unicode.h
 
 # Add compatibility layer for WinPR if not available

--- a/src/protocols/rdp/guac_handlers.c
+++ b/src/protocols/rdp/guac_handlers.c
@@ -480,6 +480,13 @@ int rdp_guac_client_size_handler(guac_client* client, int width, int height) {
 
     freerdp* rdp_inst = guac_client_data->rdp_inst;
 
+    /* Convert client pixels to remote pixels */
+    width  = width  * guac_client_data->settings.resolution
+                    / client->info.optimal_resolution;
+
+    height = height * guac_client_data->settings.resolution
+                    / client->info.optimal_resolution;
+
     /* Send display update */
     pthread_mutex_lock(&(guac_client_data->rdp_lock));
     guac_rdp_disp_set_size(guac_client_data->disp, rdp_inst->context,

--- a/src/protocols/rdp/rdp_settings.h
+++ b/src/protocols/rdp/rdp_settings.h
@@ -123,6 +123,12 @@ typedef struct guac_rdp_settings {
     int height;
 
     /**
+     * The DPI of the remote display to assume when converting between
+     * client pixels and remote pixels.
+     */
+    int resolution;
+
+    /**
      * Whether audio is enabled.
      */
     int audio_enabled;

--- a/src/protocols/rdp/resolution.c
+++ b/src/protocols/rdp/resolution.c
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2014 Glyptodon LLC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "client.h"
+#include "resolution.h"
+
+#include <guacamole/client.h>
+
+int guac_rdp_resolution_reasonable(guac_client* client, int resolution) {
+
+    int width  = client->info.optimal_width;
+    int height = client->info.optimal_height;
+
+    /* Convert client pixels to remote pixels */
+    width  = width  * resolution / client->info.optimal_resolution;
+    height = height * resolution / client->info.optimal_resolution;
+
+    /*
+     * Resolution is reasonable if the same as the client optimal resolution
+     * OR if the resulting display area is reasonable
+     */
+    return client->info.optimal_resolution == resolution
+        || width*height >= GUAC_RDP_REASONABLE_AREA;
+
+}
+
+int guac_rdp_suggest_resolution(guac_client* client) {
+
+    /* Prefer RDP's native resolution */
+    if (guac_rdp_resolution_reasonable(client, GUAC_RDP_NATIVE_RESOLUTION))
+        return GUAC_RDP_NATIVE_RESOLUTION;
+
+    /* If native resolution is too tiny, try higher resolution */
+    if (guac_rdp_resolution_reasonable(client, GUAC_RDP_HIGH_RESOLUTION))
+        return GUAC_RDP_HIGH_RESOLUTION;
+
+    /* Fallback to client-suggested resolution */
+    return client->info.optimal_resolution;
+
+}
+

--- a/src/protocols/rdp/resolution.h
+++ b/src/protocols/rdp/resolution.h
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2014 Glyptodon LLC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef GUAC_RDP_RESOLUTION_H
+#define GUAC_RDP_RESOLUTION_H
+
+#include <guacamole/client.h>
+
+/**
+ * Returns whether the given resolution is reasonable for the given client,
+ * based on arbitrary criteria for reasonability.
+ *
+ * @param client The guac_client to test the given resolution against.
+ * @param resolution The resolution to test, in DPI.
+ * @return Non-zero if the resolution is reasonable, zero otherwise.
+ */
+int guac_rdp_resolution_reasonable(guac_client* client, int resolution);
+
+/**
+ * Returns a reasonable resolution for the remote display, given the size and
+ * resolution of a guac_client.
+ *
+ * @param client The guac_client whose size and resolution shall be used to
+ *               determine an appropriate remote display resolution.
+ * @return A reasonable resolution for the remote display, in DPI.
+ */
+int guac_rdp_suggest_resolution(guac_client* client);
+
+#endif
+


### PR DESCRIPTION
This change modifies the manner in which effective display resolution is decided and stored:
1. The requested DPI is maintained throughout the session, along with the requested width/height, rather than overwriting the client optimal resolution and dimensions.
2. If the DPI is not forced via the "dpi" parameter, heuristics determine a "reasonable" resolution based on resulting screen area.
3. Future size requests are adjusted to remote coordinates, such that the effective DPI of the session is consistent.
