### PR TITLE
GUAC-945: Do not attempt to load drdynvc unless Display Update is in use.

### DIFF
--- a/src/protocols/rdp/client.c
+++ b/src/protocols/rdp/client.c
@@ -212,12 +212,6 @@ BOOL rdp_freerdp_pre_connect(freerdp* instance) {
     freerdp_register_addin_provider(freerdp_channels_load_static_addin_entry, 0);
 #endif
 
-    /* Load virtual channel management plugin */
-    if (freerdp_channels_load_plugin(channels, instance->settings,
-                "drdynvc", instance->settings))
-        guac_client_log(client, GUAC_LOG_WARNING,
-                "Failed to load drdynvc plugin.");
-
 #ifdef HAVE_FREERDP_EVENT_PUBSUB
     /* Subscribe to and handle channel connected events */
     PubSub_SubscribeChannelConnected(context->pubSub,
@@ -225,6 +219,12 @@ BOOL rdp_freerdp_pre_connect(freerdp* instance) {
 #endif
 
 #ifdef HAVE_FREERDP_DISPLAY_UPDATE_SUPPORT
+    /* Load virtual channel management plugin */
+    if (freerdp_channels_load_plugin(channels, instance->settings,
+                "drdynvc", instance->settings))
+        guac_client_log(client, GUAC_LOG_WARNING,
+                "Failed to load drdynvc plugin.");
+
     /* Init display update plugin */
     guac_client_data->disp = guac_rdp_disp_alloc();
     guac_rdp_disp_load_plugin(instance->context);


### PR DESCRIPTION
The drdynvc plugin apparently uses a different interface in the older versions of FreeRDP, and segfaults unless the arbitrary plugin data is somehow preinitialized with the plugin path. None of the example clients actually use this plugin, so there's no documentation on how this needs to be done.

It's easy enough to only load drdynvc when we actually need it (when Display Update is going to be used). In such a case, it's properly initialized upon load, and there is no segfault.
