### PR TITLE
GUAC-974: Add logging and error reporting to avoid key confusion.

### DIFF
--- a/src/protocols/ssh/ssh_client.c
+++ b/src/protocols/ssh/ssh_client.c
@@ -385,7 +385,9 @@ void* ssh_client_thread(void* data) {
 
             /* If still failing, give up */
             if (client_data->key == NULL) {
-                guac_client_log(client, GUAC_LOG_ERROR, "Auth key import failed.");
+                guac_client_abort(client,
+                        GUAC_PROTOCOL_STATUS_CLIENT_UNAUTHORIZED,
+                        "Auth key import failed.");
                 return NULL;
             }
 

--- a/src/protocols/ssh/ssh_client.c
+++ b/src/protocols/ssh/ssh_client.c
@@ -36,6 +36,7 @@
 #include <guacamole/client.h>
 #include <guacamole/protocol.h>
 #include <guacamole/socket.h>
+#include <openssl/err.h>
 #include <openssl/ssl.h>
 
 #ifdef LIBSSH2_USES_GCRYPT
@@ -351,7 +352,9 @@ void* ssh_client_thread(void* data) {
     CRYPTO_set_id_callback(__openssl_id_callback);
     CRYPTO_set_locking_callback(__openssl_locking_callback);
 
+    /* Init OpenSSL */
     SSL_library_init();
+    ERR_load_crypto_strings();
     libssh2_init(0);
 
     /* Get username */
@@ -366,12 +369,22 @@ void* ssh_client_thread(void* data) {
     /* If key specified, import */
     if (client_data->key_base64[0] != 0) {
 
+        guac_client_log(client, GUAC_LOG_DEBUG,
+                "Attempting private key import (WITHOUT passphrase)");
+
         /* Attempt to read key without passphrase */
         client_data->key = ssh_key_alloc(client_data->key_base64,
                 strlen(client_data->key_base64), "");
 
         /* On failure, attempt with passphrase */
         if (client_data->key == NULL) {
+
+            /* Log failure of initial attempt */
+            guac_client_log(client, GUAC_LOG_DEBUG,
+                    "Initial import failed: %s", ssh_key_error());
+
+            guac_client_log(client, GUAC_LOG_DEBUG,
+                    "Re-attempting private key import (WITH passphrase)");
 
             /* Prompt for passphrase if missing */
             if (client_data->key_passphrase[0] == 0)
@@ -387,7 +400,7 @@ void* ssh_client_thread(void* data) {
             if (client_data->key == NULL) {
                 guac_client_abort(client,
                         GUAC_PROTOCOL_STATUS_CLIENT_UNAUTHORIZED,
-                        "Auth key import failed.");
+                        "Auth key import failed: %s", ssh_key_error());
                 return NULL;
             }
 

--- a/src/protocols/ssh/ssh_key.c
+++ b/src/protocols/ssh/ssh_key.c
@@ -28,6 +28,7 @@
 #include <openssl/bio.h>
 #include <openssl/bn.h>
 #include <openssl/dsa.h>
+#include <openssl/err.h>
 #include <openssl/evp.h>
 #include <openssl/obj_mac.h>
 #include <openssl/pem.h>
@@ -130,6 +131,13 @@ ssh_key* ssh_key_alloc(char* data, int length, char* passphrase) {
 
     BIO_free(key_bio);
     return key;
+
+}
+
+const char* ssh_key_error() {
+
+    /* Return static error string */
+    return ERR_reason_error_string(ERR_get_error());
 
 }
 

--- a/src/protocols/ssh/ssh_key.h
+++ b/src/protocols/ssh/ssh_key.h
@@ -114,6 +114,15 @@ typedef struct ssh_key {
 ssh_key* ssh_key_alloc(char* data, int length, char* passphrase);
 
 /**
+ * Returns a statically-allocated string describing the most recent SSH key
+ * error.
+ *
+ * @return
+ *     A statically-allocated string describing the most recent SSH key error.
+ */
+const char* ssh_key_error();
+
+/**
  * Frees all memory associated with the given key.
  */
 void ssh_key_free(ssh_key* key);


### PR DESCRIPTION
Auth keys are actually properly handled - logging of errors is simply lacking or confusing. This change addresses that deficiency.