### PR TITLE
GUAC-996: Do not reset clip upon resize. Fix copy of surface data.

### DIFF
--- a/src/common/guac_surface.c
+++ b/src/common/guac_surface.c
@@ -718,10 +718,10 @@ void guac_common_surface_resize(guac_common_surface* surface, int w, int h) {
     surface->height = h;
     surface->stride = cairo_format_stride_for_width(CAIRO_FORMAT_RGB24, w);
     surface->buffer = calloc(h, surface->stride);
-    guac_common_surface_reset_clip(surface);
+    __guac_common_bound_rect(surface, &surface->clip_rect, NULL, NULL);
 
     /* Copy relevant old data */
-    guac_common_rect_constrain(&old_rect, &surface->clip_rect);
+    __guac_common_bound_rect(surface, &old_rect, NULL, NULL);
     __guac_common_surface_put(old_buffer, old_stride, &sx, &sy, surface, &old_rect, 1);
 
     /* Free old data */


### PR DESCRIPTION
The surface code previously (and erroneously) reset the clipping rectangle whenever the surface was resized. It now simply adjusts the clipping rectangle to fit within the new surface dimensions.

Similarly, the old code would copy data using the clipping rectangle as the basis for that copy, under the assumption it would occupy the entire surface. This is fixed, too.