### PR TITLE
GUAC-1008: Properly init clipping rectangle.

### DIFF
--- a/src/common/guac_surface.c
+++ b/src/common/guac_surface.c
@@ -122,6 +122,10 @@ static void __guac_common_clip_rect(guac_common_surface* surface,
     int orig_x = rect->x;
     int orig_y = rect->y;
 
+    /* Skip clipping if no clipping rectangle applied */
+    if (!surface->clipped)
+        return;
+
     guac_common_rect_constrain(rect, &surface->clip_rect);
 
     /* Update source X/Y if given */
@@ -727,9 +731,9 @@ void guac_common_surface_resize(guac_common_surface* surface, int w, int h) {
     /* Free old data */
     free(old_buffer);
 
-    /* Clip dirty rect */
+    /* Resize dirty rect to fit new surface dimensions */
     if (surface->dirty) {
-        guac_common_rect_constrain(&surface->dirty_rect, &surface->clip_rect);
+        __guac_common_bound_rect(surface, &surface->dirty_rect, NULL, NULL);
         if (surface->dirty_rect.width <= 0 || surface->dirty_rect.height <= 0)
             surface->dirty = 0;
     }
@@ -923,13 +927,19 @@ void guac_common_surface_clip(guac_common_surface* surface, int x, int y, int w,
 
     guac_common_rect clip;
 
+    /* Init clipping rectangle if clipping not already applied */
+    if (!surface->clipped) {
+        guac_common_rect_init(&surface->clip_rect, 0, 0, surface->width, surface->height);
+        surface->clipped = 1;
+    }
+
     guac_common_rect_init(&clip, x, y, w, h);
     guac_common_rect_constrain(&surface->clip_rect, &clip);
 
 }
 
 void guac_common_surface_reset_clip(guac_common_surface* surface) {
-    guac_common_rect_init(&surface->clip_rect, 0, 0, surface->width, surface->height);
+    surface->clipped = 0;
 }
 
 /**

--- a/src/common/guac_surface.h
+++ b/src/common/guac_surface.h
@@ -106,6 +106,12 @@ typedef struct guac_common_surface {
     int realized;
 
     /**
+     * Whether drawing operations are currently clipped by the clipping
+     * rectangle.
+     */
+    int clipped;
+
+    /**
      * The clipping rectangle.
      */
     guac_common_rect clip_rect;


### PR DESCRIPTION
Since the surface used by the terminal code resizes (unlike VNC) and does not use clipping (unlike RDP), recent changes in GUAC-996 caused a regression not noticed during testing (which was restricted to VNC and RDP).

When the clipping rectangle is updated to fit within the new display size, this only makes sense when a clipping rectangle has actually been set. In the case of RDP, the clipping rectangle is reset after each drawing operation, but the terminal code will only reset the clipping rectangle in when the surface is allocated, at which point the rectangle is 0x0, thus everything is clipped.

This change properly initializes the clipping rectangle when clipping is used, and does not pay attention to the clipping rectangle unless it has been explicitly set, thanks to a "clipped" flag.