### PR TITLE
GUAC-803: Add scrollbar to right of terminal display.

### DIFF
--- a/src/terminal/Makefile.am
+++ b/src/terminal/Makefile.am
@@ -34,6 +34,7 @@ noinst_HEADERS =                \
     cursor.h                    \
     display.h                   \
     ibar.h                      \
+    scrollbar.h                 \
     terminal.h                  \
     terminal_handlers.h         \
     types.h
@@ -46,6 +47,7 @@ libguac_terminal_la_SOURCES =   \
     cursor.c                    \
     display.c                   \
     ibar.c                      \
+    scrollbar.c                 \
     terminal.c                  \
     terminal_handlers.c
 

--- a/src/terminal/scrollbar.c
+++ b/src/terminal/scrollbar.c
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2015 Glyptodon LLC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "config.h"
+#include "scrollbar.h"
+
+#include <guacamole/client.h>
+#include <guacamole/layer.h>
+
+#include <stdlib.h>
+
+guac_terminal_scrollbar* guac_terminal_scrollbar_alloc(guac_client* client,
+        guac_layer* parent, int parent_width, int parent_height) {
+    /* STUB */
+    return NULL;
+}
+
+void guac_terminal_scrollbar_free(guac_terminal_scrollbar* scrollbar) {
+    /* STUB */
+}
+
+void guac_terminal_scrollbar_set_bounds(guac_terminal_scrollbar* scrollbar,
+        int min, int max) {
+    /* STUB */
+}
+
+void guac_terminal_scrollbar_set_value(guac_terminal_scrollbar* scrollbar,
+        int value) {
+    /* STUB */
+}
+
+void guac_terminal_scrollbar_parent_resized(guac_terminal_scrollbar* scrollbar,
+        int parent_width, int parent_height) {
+    /* STUB */
+}
+

--- a/src/terminal/scrollbar.c
+++ b/src/terminal/scrollbar.c
@@ -117,7 +117,11 @@ static void __update_box(guac_terminal_scrollbar* scrollbar) {
 
     /* Fill box with solid color */
     guac_protocol_send_rect(socket, scrollbar->box, 0, 0, box_width, box_height);
-    guac_protocol_send_cfill(socket, GUAC_COMP_SRC, scrollbar->box, 0xFF, 0xFF, 0xFF, 0x80);
+    guac_protocol_send_cfill(socket, GUAC_COMP_SRC, scrollbar->box,
+            0x80, 0x80, 0x80, 0xFF);
+    guac_protocol_send_cstroke(socket, GUAC_COMP_OVER, scrollbar->box,
+            GUAC_LINE_CAP_SQUARE, GUAC_LINE_JOIN_MITER, 2,
+            0xA0, 0xA0, 0xA0, 0xFF);
 
 }
 
@@ -175,6 +179,12 @@ void guac_terminal_scrollbar_parent_resized(guac_terminal_scrollbar* scrollbar,
     /* Resize to fit within parent */
     guac_protocol_send_size(socket, scrollbar->container,
             container_width, container_height);
+
+    /* Fill container with solid color */
+    guac_protocol_send_rect(socket, scrollbar->container, 0, 0,
+            container_width, container_height);
+    guac_protocol_send_cfill(socket, GUAC_COMP_SRC, scrollbar->container,
+            0x40, 0x40, 0x40, 0xFF);
 
     /* Assign new dimensions */
     scrollbar->parent_width  = parent_width;

--- a/src/terminal/scrollbar.c
+++ b/src/terminal/scrollbar.c
@@ -53,7 +53,7 @@ guac_terminal_scrollbar* guac_terminal_scrollbar_alloc(guac_client* client,
 
     /* Allocate and init layers */
     scrollbar->container = guac_client_alloc_layer(client);
-    scrollbar->box       = guac_client_alloc_layer(client);
+    scrollbar->handle    = guac_client_alloc_layer(client);
 
     /* Reposition and resize to fit parent */
     guac_terminal_scrollbar_parent_resized(scrollbar,
@@ -66,7 +66,7 @@ guac_terminal_scrollbar* guac_terminal_scrollbar_alloc(guac_client* client,
 void guac_terminal_scrollbar_free(guac_terminal_scrollbar* scrollbar) {
 
     /* Free layers */
-    guac_client_free_layer(scrollbar->client, scrollbar->box);
+    guac_client_free_layer(scrollbar->client, scrollbar->handle);
     guac_client_free_layer(scrollbar->client, scrollbar->container);
 
     /* Free scrollbar */
@@ -75,13 +75,13 @@ void guac_terminal_scrollbar_free(guac_terminal_scrollbar* scrollbar) {
 }
 
 /**
- * Updates the position and size of the scrollbar inner box relative to the
+ * Updates the position and size of the scrollbar handle relative to the
  * current scrollbar value, bounds, and parent layer dimensions.
  *
  * @param scrollbar
- *     The scrollbar whose inner box should be updated.
+ *     The scrollbar whose handle should be updated.
  */
-static void __update_box(guac_terminal_scrollbar* scrollbar) {
+static void __update_handle(guac_terminal_scrollbar* scrollbar) {
 
     guac_socket* socket = scrollbar->client->socket;
 
@@ -91,35 +91,35 @@ static void __update_box(guac_terminal_scrollbar* scrollbar) {
 
     int region_size = scrollbar->max - scrollbar->min;
 
-    /* Calculate box dimensions */
-    int box_width  = GUAC_TERMINAL_SCROLLBAR_WIDTH - GUAC_TERMINAL_SCROLLBAR_PADDING*2;
-    int box_height = GUAC_TERMINAL_SCROLLBAR_MIN_HEIGHT;
+    /* Calculate handle dimensions */
+    int handle_width  = GUAC_TERMINAL_SCROLLBAR_WIDTH - GUAC_TERMINAL_SCROLLBAR_PADDING*2;
+    int handle_height = GUAC_TERMINAL_SCROLLBAR_MIN_HEIGHT;
 
-    /* Size box relative to visible area */
+    /* Size handle relative to visible area */
     int padded_container_height = (scrollbar->parent_height - GUAC_TERMINAL_SCROLLBAR_PADDING*2);
     int proportional_height = padded_container_height * scrollbar->visible_area / (region_size + scrollbar->visible_area);
-    if (proportional_height > box_height)
-        box_height = proportional_height;
+    if (proportional_height > handle_height)
+        handle_height = proportional_height;
 
-    /* Calculate box position and dimensions */
-    int box_x = GUAC_TERMINAL_SCROLLBAR_PADDING;
-    int box_y = GUAC_TERMINAL_SCROLLBAR_PADDING
-              + (padded_container_height - box_height) * (scrollbar->value - scrollbar->min) / region_size;
+    /* Calculate handle position and dimensions */
+    int handle_x = GUAC_TERMINAL_SCROLLBAR_PADDING;
+    int handle_y = GUAC_TERMINAL_SCROLLBAR_PADDING
+              + (padded_container_height - handle_height) * (scrollbar->value - scrollbar->min) / region_size;
 
-    /* Reposition box relative to container and current value */
+    /* Reposition handle relative to container and current value */
     guac_protocol_send_move(socket,
-            scrollbar->box, scrollbar->container,
-            box_x, box_y, 0);
+            scrollbar->handle, scrollbar->container,
+            handle_x, handle_y, 0);
 
-    /* Resize box relative to scrollable area */
-    guac_protocol_send_size(socket, scrollbar->box,
-            box_width, box_height);
+    /* Resize handle relative to scrollable area */
+    guac_protocol_send_size(socket, scrollbar->handle,
+            handle_width, handle_height);
 
-    /* Fill box with solid color */
-    guac_protocol_send_rect(socket, scrollbar->box, 0, 0, box_width, box_height);
-    guac_protocol_send_cfill(socket, GUAC_COMP_SRC, scrollbar->box,
+    /* Fill handle with solid color */
+    guac_protocol_send_rect(socket, scrollbar->handle, 0, 0, handle_width, handle_height);
+    guac_protocol_send_cfill(socket, GUAC_COMP_SRC, scrollbar->handle,
             0x80, 0x80, 0x80, 0xFF);
-    guac_protocol_send_cstroke(socket, GUAC_COMP_OVER, scrollbar->box,
+    guac_protocol_send_cstroke(socket, GUAC_COMP_OVER, scrollbar->handle,
             GUAC_LINE_CAP_SQUARE, GUAC_LINE_JOIN_MITER, 2,
             0xA0, 0xA0, 0xA0, 0xFF);
 
@@ -138,8 +138,8 @@ void guac_terminal_scrollbar_set_bounds(guac_terminal_scrollbar* scrollbar,
     scrollbar->min = min;
     scrollbar->max = max;
 
-    /* Update box position and size */
-    __update_box(scrollbar);
+    /* Update handle position and size */
+    __update_handle(scrollbar);
 
 }
 
@@ -155,8 +155,8 @@ void guac_terminal_scrollbar_set_value(guac_terminal_scrollbar* scrollbar,
     /* Update value */
     scrollbar->value = value;
 
-    /* Update box position and size */
-    __update_box(scrollbar);
+    /* Update handle position and size */
+    __update_handle(scrollbar);
 
 }
 
@@ -191,8 +191,8 @@ void guac_terminal_scrollbar_parent_resized(guac_terminal_scrollbar* scrollbar,
     scrollbar->parent_height = parent_height;
     scrollbar->visible_area  = visible_area;
 
-    /* Update box position and size */
-    __update_box(scrollbar);
+    /* Update handle position and size */
+    __update_handle(scrollbar);
 
 }
 

--- a/src/terminal/scrollbar.h
+++ b/src/terminal/scrollbar.h
@@ -79,7 +79,7 @@ typedef struct guac_terminal_scrollbar {
      * The movable box within the scrollbar, representing the current scroll
      * value.
      */
-    guac_layer* layer;
+    guac_layer* box;
 
     /**
      * The minimum scroll value.
@@ -123,7 +123,7 @@ typedef struct guac_terminal_scrollbar {
  *     A newly allocated scrollbar.
  */
 guac_terminal_scrollbar* guac_terminal_scrollbar_alloc(guac_client* client,
-        guac_layer* parent, int parent_width, int parent_height);
+        const guac_layer* parent, int parent_width, int parent_height);
 
 /**
  * Frees the given scrollbar.

--- a/src/terminal/scrollbar.h
+++ b/src/terminal/scrollbar.h
@@ -1,0 +1,193 @@
+/*
+ * Copyright (C) 2015 Glyptodon LLC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef GUAC_TERMINAL_SCROLLBAR_H
+#define GUAC_TERMINAL_SCROLLBAR_H
+
+#include "config.h"
+
+#include <guacamole/client.h>
+#include <guacamole/layer.h>
+
+/**
+ * The width of the scrollbar, in pixels.
+ */
+#define GUAC_TERMINAL_SCROLLBAR_WIDTH 16 
+
+/**
+ * The number of pixels between the inner box of the scrollbar and the outer
+ * box.
+ */
+#define GUAC_TERMINAL_SCROLLBAR_PADDING 2
+
+/**
+ * The minimum height of the inner box of the scrollbar, in pixels.
+ */
+#define GUAC_TERMINAL_SCROLLBAR_MIN_HEIGHT 64
+
+/**
+ * A scrollbar, made up of an outer and inner box, which represents its value
+ * graphically by the relative position and size of the inner box.
+ */
+typedef struct guac_terminal_scrollbar {
+
+    /**
+     * The client associated with this scrollbar.
+     */
+    guac_client* client;
+
+    /**
+     * The layer containing the scrollbar.
+     */
+    const guac_layer* parent;
+
+    /**
+     * The width of the parent layer, in pixels.
+     */
+    int parent_width;
+
+    /**
+     * The height of the parent layer, in pixels.
+     */
+    int parent_height;
+
+    /**
+     * The scrollbar itself.
+     */
+    guac_layer* container;
+
+    /**
+     * The movable box within the scrollbar, representing the current scroll
+     * value.
+     */
+    guac_layer* layer;
+
+    /**
+     * The minimum scroll value.
+     */
+    int min;
+
+    /**
+     * The maximum scroll value.
+     */
+    int max;
+
+    /**
+     * The current scroll value.
+     */
+    int value;
+
+} guac_terminal_scrollbar;
+
+/**
+ * Allocates a new scrollbar, associating that scrollbar with the given client
+ * and parent layer. The dimensions of the parent layer dictate the initial
+ * position of the scrollbar. Currently, the scrollbar is always anchored to
+ * the right edge of the parent layer.
+ *
+ * This will cause instructions to be written to the client's socket, but the
+ * client's socket will not be automatically flushed.
+ *
+ * @param client
+ *     The client to associate with the new scrollbar.
+ *
+ * @param parent
+ *     The layer which will contain the newly-allocated scrollbar.
+ *
+ * @param parent_width
+ *     The width of the parent layer, in pixels.
+ *
+ * @param parent_height
+ *     The height of the parent layer, in pixels.
+ *
+ * @return
+ *     A newly allocated scrollbar.
+ */
+guac_terminal_scrollbar* guac_terminal_scrollbar_alloc(guac_client* client,
+        guac_layer* parent, int parent_width, int parent_height);
+
+/**
+ * Frees the given scrollbar.
+ *
+ * @param scrollbar
+ *     The scrollbar to free.
+ */
+void guac_terminal_scrollbar_free(guac_terminal_scrollbar* scrollbar);
+
+/**
+ * Sets the minimum and maximum allowed scroll values of the given scrollbar
+ * to the given values. If necessary, the current value of the scrollbar will
+ * be adjusted to fit within the new bounds.
+ *
+ * This may cause instructions to be written to the client's socket, but the
+ * client's socket will not be automatically flushed.
+ *
+ * @param scrollbar
+ *     The scrollbar whose bounds are changing.
+ *
+ * @param min
+ *     The new minimum value of the scrollbar.
+ *
+ * @param max
+ *     The new maximum value of the scrollbar.
+ */
+void guac_terminal_scrollbar_set_bounds(guac_terminal_scrollbar* scrollbar,
+        int min, int max);
+
+/**
+ * Sets the current value of the given scrollbar. If the value specified does
+ * not fall within the scrollbar's defined minimum and maximum values, the
+ * value will be adjusted to fit.
+ *
+ * This may cause instructions to be written to the client's socket, but the
+ * client's socket will not be automatically flushed.
+ *
+ * @param scrollbar
+ *     The scrollbar whose value is changing.
+ *
+ * @param value
+ *     The value to assign to the scrollbar. If the value if out of bounds, it
+ *     will be automatically adjusted to fit.
+ */
+void guac_terminal_scrollbar_set_value(guac_terminal_scrollbar* scrollbar,
+        int value);
+
+/**
+ * Notifies the scrollbar that the parent layer has been resized, and that the
+ * scrollbar may need to be repositioned or resized accordingly.
+ *
+ * This may cause instructions to be written to the client's socket, but the
+ * client's socket will not be automatically flushed.
+ *
+ * @param scrollbar
+ *     The scrollbar whose parent layer has been resized.
+ *
+ * @param parent_width
+ *     The new width of the parent layer, in pixels.
+ *
+ * @param parent_height
+ *     The new height of the parent layer, in pixels.
+ */
+void guac_terminal_scrollbar_parent_resized(guac_terminal_scrollbar* scrollbar,
+        int parent_width, int parent_height);
+
+#endif

--- a/src/terminal/scrollbar.h
+++ b/src/terminal/scrollbar.h
@@ -34,19 +34,20 @@
 #define GUAC_TERMINAL_SCROLLBAR_WIDTH 16 
 
 /**
- * The number of pixels between the inner box of the scrollbar and the outer
- * box.
+ * The number of pixels between the draggable handle of the scrollbar and the
+ * boundary of the containing layer.
  */
 #define GUAC_TERMINAL_SCROLLBAR_PADDING 2
 
 /**
- * The minimum height of the inner box of the scrollbar, in pixels.
+ * The minimum height of the draggable handle of the scrollbar, in pixels.
  */
 #define GUAC_TERMINAL_SCROLLBAR_MIN_HEIGHT 64
 
 /**
- * A scrollbar, made up of an outer and inner box, which represents its value
- * graphically by the relative position and size of the inner box.
+ * A scrollbar, made up of a containing layer and inner draggable handle. The
+ * position of the handle within the layer represents the value of the
+ * scrollbar.
  */
 typedef struct guac_terminal_scrollbar {
 
@@ -76,10 +77,10 @@ typedef struct guac_terminal_scrollbar {
     guac_layer* container;
 
     /**
-     * The movable box within the scrollbar, representing the current scroll
-     * value.
+     * The draggable handle within the scrollbar, representing the current
+     * scroll value.
      */
-    guac_layer* box;
+    guac_layer* handle;
 
     /**
      * The minimum scroll value.

--- a/src/terminal/scrollbar.h
+++ b/src/terminal/scrollbar.h
@@ -92,6 +92,11 @@ typedef struct guac_terminal_scrollbar {
     int max;
 
     /**
+     * The size of the visible area, in the same units as min and max.
+     */
+    int visible_area;
+
+    /**
      * The current scroll value.
      */
     int value;
@@ -119,11 +124,17 @@ typedef struct guac_terminal_scrollbar {
  * @param parent_height
  *     The height of the parent layer, in pixels.
  *
+ * @param visible_area
+ *     The amount of scrollable data that can be shown within the parent layer
+ *     at any given time. This value uses the same units as min, max, and the
+ *     current scroll value.
+ *
  * @return
  *     A newly allocated scrollbar.
  */
 guac_terminal_scrollbar* guac_terminal_scrollbar_alloc(guac_client* client,
-        const guac_layer* parent, int parent_width, int parent_height);
+        const guac_layer* parent, int parent_width, int parent_height,
+        int visible_area);
 
 /**
  * Frees the given scrollbar.
@@ -186,8 +197,13 @@ void guac_terminal_scrollbar_set_value(guac_terminal_scrollbar* scrollbar,
  *
  * @param parent_height
  *     The new height of the parent layer, in pixels.
+ *
+ * @param visible_area
+ *     The amount of scrollable data that can be shown within the parent layer
+ *     at any given time. This value uses the same units as min, max, and the
+ *     current scroll value.
  */
 void guac_terminal_scrollbar_parent_resized(guac_terminal_scrollbar* scrollbar,
-        int parent_width, int parent_height);
+        int parent_width, int parent_height, int visible_area);
 
 #endif

--- a/src/terminal/scrollbar.h
+++ b/src/terminal/scrollbar.h
@@ -45,6 +45,58 @@
 #define GUAC_TERMINAL_SCROLLBAR_MIN_HEIGHT 64
 
 /**
+ * The state of all scrollbar components, describing all variable aspects of
+ * the scrollbar's appearance.
+ */
+typedef struct guac_terminal_scrollbar_render_state {
+
+    /**
+     * The current X-coordinate of the upper-left corner of the scrollbar's
+     * handle. This value will be relative to the scrollbar's containing layer.
+     */
+    int handle_x;
+
+    /**
+     * The current Y-coordinate of the upper-left corner of the scrollbar's
+     * handle. This value will be relative to the scrollbar's containing layer.
+     */
+    int handle_y;
+
+    /**
+     * The width of the scrollbar's handle.
+     */
+    int handle_width;
+
+    /**
+     * The height of the scrollbar's handle.
+     */
+    int handle_height;
+
+    /**
+     * The current X-coordinate of the upper-left corner of the scrollbar's
+     * containing layer.
+     */
+    int container_x;
+
+    /**
+     * The current Y-coordinate of the upper-left corner of the scrollbar's
+     * containing layer.
+     */
+    int container_y;
+
+    /**
+     * The width of the scrollbar's containing layer.
+     */
+    int container_width;
+
+    /**
+     * The height of the scrollbar's containing layer.
+     */
+    int container_height;
+
+} guac_terminal_scrollbar_render_state;
+
+/**
  * A scrollbar, made up of a containing layer and inner draggable handle. The
  * position of the handle within the layer represents the value of the
  * scrollbar.
@@ -102,6 +154,11 @@ typedef struct guac_terminal_scrollbar {
      */
     int value;
 
+    /**
+     * The current state of all variable, visible parts of the scrollbar.
+     */
+    guac_terminal_scrollbar_render_state render_state;
+
 } guac_terminal_scrollbar;
 
 /**
@@ -144,6 +201,18 @@ guac_terminal_scrollbar* guac_terminal_scrollbar_alloc(guac_client* client,
  *     The scrollbar to free.
  */
 void guac_terminal_scrollbar_free(guac_terminal_scrollbar* scrollbar);
+
+/**
+ * Flushes the render state of the given scrollbar, updating the remote display
+ * accordingly.
+ *
+ * This may cause instructions to be written to the client's socket, but the
+ * client's socket will not be automatically flushed.
+ *
+ * @param scrollbar
+ *     The scrollbar whose render state is to be flushed.
+ */
+void guac_terminal_scrollbar_flush(guac_terminal_scrollbar* scrollbar);
 
 /**
  * Sets the minimum and maximum allowed scroll values of the given scrollbar

--- a/src/terminal/terminal.c
+++ b/src/terminal/terminal.c
@@ -682,6 +682,8 @@ void guac_terminal_scroll_display_down(guac_terminal* terminal,
     }
 
     guac_terminal_display_flush(terminal->display);
+    guac_terminal_scrollbar_flush(terminal->scrollbar);
+
     guac_protocol_send_sync(terminal->client->socket,
             terminal->client->last_sent_timestamp);
     guac_socket_flush(terminal->client->socket);
@@ -747,6 +749,8 @@ void guac_terminal_scroll_display_up(guac_terminal* terminal,
     }
 
     guac_terminal_display_flush(terminal->display);
+    guac_terminal_scrollbar_flush(terminal->scrollbar);
+
     guac_protocol_send_sync(terminal->client->socket,
             terminal->client->last_sent_timestamp);
     guac_socket_flush(terminal->client->socket);
@@ -1170,6 +1174,7 @@ int guac_terminal_resize(guac_terminal* terminal, int width, int height) {
 
     /* If terminal size hasn't changed, still need to flush */
     else {
+        guac_terminal_scrollbar_flush(terminal->scrollbar);
         guac_protocol_send_sync(socket, client->last_sent_timestamp);
         guac_socket_flush(socket);
     }
@@ -1181,6 +1186,7 @@ int guac_terminal_resize(guac_terminal* terminal, int width, int height) {
 void guac_terminal_flush(guac_terminal* terminal) {
     guac_terminal_commit_cursor(terminal);
     guac_terminal_display_flush(terminal->display);
+    guac_terminal_scrollbar_flush(terminal->scrollbar);
 }
 
 void guac_terminal_lock(guac_terminal* terminal) {

--- a/src/terminal/terminal.c
+++ b/src/terminal/terminal.c
@@ -202,6 +202,11 @@ guac_terminal* guac_terminal_create(guac_client* client,
         },
         .width = 1};
 
+    /* Calculate available display area */
+    int available_width = width - GUAC_TERMINAL_SCROLLBAR_WIDTH;
+    if (available_width < 0)
+        available_width = 0;
+
     guac_terminal* term = malloc(sizeof(guac_terminal));
     term->client = client;
     term->upload_path_handler = NULL;
@@ -227,7 +232,7 @@ guac_terminal* guac_terminal_create(guac_client* client,
     term->current_attributes = default_char.attributes;
     term->default_char = default_char;
 
-    term->term_width   = width  / term->display->char_width;
+    term->term_width   = available_width / term->display->char_width;
     term->term_height  = height / term->display->char_height;
 
     /* Open STDOUT pipe */
@@ -1146,9 +1151,14 @@ int guac_terminal_resize(guac_terminal* terminal, int width, int height) {
     guac_client* client = display->client;
     guac_socket* socket = client->socket;
 
+    /* Calculate available display area */
+    int available_width = width - GUAC_TERMINAL_SCROLLBAR_WIDTH;
+    if (available_width < 0)
+        available_width = 0;
+
     /* Calculate dimensions */
     int rows    = height / display->char_height;
-    int columns = width  / display->char_width;
+    int columns = available_width / display->char_width;
 
     /* Resize default layer to given pixel dimensions */
     guac_protocol_send_size(socket, GUAC_DEFAULT_LAYER, width, height);

--- a/src/terminal/terminal.h
+++ b/src/terminal/terminal.h
@@ -30,6 +30,7 @@
 #include "cursor.h"
 #include "display.h"
 #include "guac_clipboard.h"
+#include "scrollbar.h"
 #include "types.h"
 
 #include <pthread.h>
@@ -116,6 +117,11 @@ struct guac_terminal {
      * this pipe.
      */
     int stdin_pipe_fd[2];
+
+    /**
+     * Graphical representation of the current scroll state.
+     */
+    guac_terminal_scrollbar* scrollbar;
 
     /**
      * The relative offset of the display. A positive value indicates that


### PR DESCRIPTION
This change adds a scrollbar to the right of the terminal display, always attached to the right side of the client display. The scrollbar updates based on the current scroll position and size of the display relative to the scrollback buffer.

The scrollbar is not yet interactive. I'll take care of that in a different PR.