### PR TITLE
GUAC-570: Solves the issue of blank pages occuring inside generated PDFs having 11 or more pages

### DIFF
--- a/src/protocols/rdp/guac_rdpdr/rdpdr_printer.c
+++ b/src/protocols/rdp/guac_rdpdr/rdpdr_printer.c
@@ -54,6 +54,7 @@ char* const guac_rdpdr_pdf_filter_command[] = {
     "-sOutputFile=-",
     "-c",
     ".setpdfwrite",
+    "-sstdout=/dev/null",
     "-f",
     "-",
     NULL


### PR DESCRIPTION
Solves the issue reported in: GUAC-570
The problem of blank pages occuring inside the generated PDF (only if it exceeds 11 pages) is due to gs generated output such as: 
%%[Page: 1]%%
%%[Page: 2]%%
...
%%[Page: n]%%
...

being written to the stdout and thus incorporated in the output PDF file. 
This tracing appear in blocks, mixed within the PDF source and make some of the pdf pages inconsistent (not formally correct).