### PR TITLE
GUAC-889: Implement lag control

### DIFF
--- a/src/libguac/client.c
+++ b/src/libguac/client.c
@@ -422,3 +422,36 @@ int guac_client_load_plugin(guac_client* client, const char* protocol) {
 
 }
 
+/**
+ * Updates the provided approximate processing lag, taking into account the
+ * processing lag of the given user.
+ *
+ * @param user
+ *     The guac_user to use to update the approximate processing lag.
+ *
+ * @param data
+ *     Pointer to an int containing the current approximate processing lag.
+ *     The int will be updated according to the processing lag of the given
+ *     user.
+ */
+static void __calculate_lag(guac_user* user, void* data) {
+
+    int* processing_lag = (int*) data;
+
+    /* Simply find maximum */
+    if (user->processing_lag > *processing_lag)
+        *processing_lag = user->processing_lag;
+
+}
+
+int guac_client_get_processing_lag(guac_client* client) {
+
+    int processing_lag = 0;
+
+    /* Approximate the processing lag of all users */
+    guac_client_foreach_user(client, __calculate_lag, &processing_lag);
+
+    return processing_lag;
+
+}
+

--- a/src/libguac/guacamole/client.h
+++ b/src/libguac/guacamole/client.h
@@ -415,6 +415,20 @@ int guac_client_end_frame(guac_client* client);
 int guac_client_load_plugin(guac_client* client, const char* protocol);
 
 /**
+ * Calculates and returns the approximate processing lag experienced by the
+ * pool of users. The processing lag is the difference in time between server
+ * and client due purely to data processing and excluding network delays.
+ *
+ * @param client
+ *     The guac_client to calculate the processing lag of.
+ *
+ * @return
+ *     The approximate processing lag of the pool of users associated with the
+ *     given guac_client, in milliseconds.
+ */
+int guac_client_get_processing_lag(guac_client* client);
+
+/**
  * The default Guacamole client layer, layer 0.
  */
 extern const guac_layer* GUAC_DEFAULT_LAYER;

--- a/src/libguac/guacamole/user.h
+++ b/src/libguac/guacamole/user.h
@@ -143,6 +143,19 @@ struct guac_user {
     guac_timestamp last_received_timestamp;
 
     /**
+     * The duration of the last frame rendered by the user, in milliseconds.
+     * This duration will include network and processing lag, and thus should
+     * be slightly higher than the true frame duration.
+     */
+    int last_frame_duration;
+
+    /**
+     * The overall lag experienced by the user relative to the stream of
+     * frames, roughly excluding network lag.
+     */
+    int processing_lag;
+
+    /**
      * Information structure containing properties exposed by the remote
      * user during the initial handshake process.
      */

--- a/src/libguac/user.c
+++ b/src/libguac/user.c
@@ -48,6 +48,8 @@ guac_user* guac_user_alloc() {
     }
 
     user->last_received_timestamp = guac_timestamp_current();
+    user->last_frame_duration = 0;
+    user->processing_lag = 0;
     user->active = 1;
 
     /* Allocate stream pool */

--- a/src/protocols/vnc/vnc.c
+++ b/src/protocols/vnc/vnc.c
@@ -140,6 +140,7 @@ rfbClient* guac_vnc_get_client(guac_client* client) {
  */
 static void guac_vnc_msleep(int msec) {
 
+    /* Split milliseconds into equivalent seconds + nanoseconds */
     struct timespec sleep_period = {
         .tv_sec  =  msec / 1000,
         .tv_nsec = (msec % 1000) * 1000000

--- a/src/protocols/vnc/vnc.c
+++ b/src/protocols/vnc/vnc.c
@@ -132,6 +132,23 @@ rfbClient* guac_vnc_get_client(guac_client* client) {
 
 }
 
+/**
+ * Sleeps for the given number of milliseconds.
+ *
+ * @param msec
+ *     The number of milliseconds to sleep;
+ */
+static void guac_vnc_msleep(int msec) {
+
+    struct timespec sleep_period = {
+        .tv_sec  =  msec / 1000,
+        .tv_nsec = (msec % 1000) * 1000000
+    };
+
+    nanosleep(&sleep_period, NULL);
+
+}
+
 void* guac_vnc_client_thread(void* data) {
 
     guac_client* client = (guac_client*) data;
@@ -151,17 +168,12 @@ void* guac_vnc_client_thread(void* data) {
     /* If unsuccessful, retry as many times as specified */
     while (!rfb_client && retries_remaining > 0) {
 
-        struct timespec guac_vnc_connect_interval = {
-            .tv_sec  =  GUAC_VNC_CONNECT_INTERVAL/1000,
-            .tv_nsec = (GUAC_VNC_CONNECT_INTERVAL%1000)*1000000
-        };
-
         guac_client_log(client, GUAC_LOG_INFO,
                 "Connect failed. Waiting %ims before retrying...",
                 GUAC_VNC_CONNECT_INTERVAL);
 
         /* Wait for given interval then retry */
-        nanosleep(&guac_vnc_connect_interval, NULL);
+        guac_vnc_msleep(GUAC_VNC_CONNECT_INTERVAL);
         rfb_client = guac_vnc_get_client(client);
         retries_remaining--;
 
@@ -231,33 +243,55 @@ void* guac_vnc_client_thread(void* data) {
 
     guac_socket_flush(client->socket);
 
+    guac_timestamp last_frame_end = guac_timestamp_current();
+
     /* Handle messages from VNC server while client is running */
     while (client->state == GUAC_CLIENT_RUNNING) {
 
-        /* Initially wait for messages */
+        /* Wait for start of frame */
         int wait_result = WaitForMessage(rfb_client, 1000000);
-        guac_timestamp frame_start = guac_timestamp_current();
-        while (wait_result > 0) {
+        if (wait_result > 0) {
 
-            guac_timestamp frame_end;
-            int frame_remaining;
+            guac_timestamp frame_start = guac_timestamp_current();
 
-            /* Handle any message received */
-            if (!HandleRFBServerMessage(rfb_client)) {
-                guac_client_abort(client, GUAC_PROTOCOL_STATUS_UPSTREAM_ERROR,
-                                  "Error handling message from VNC server.");
-                break;
-            }
+            /* Calculate time since last frame */
+            int time_elapsed = frame_start - last_frame_end;
+            int processing_lag = guac_client_get_processing_lag(client);
 
-            /* Calculate time remaining in frame */
-            frame_end = guac_timestamp_current();
-            frame_remaining = frame_start + GUAC_VNC_FRAME_DURATION - frame_end;
+            /* Force roughly-equal length of server and client frames */
+            if (time_elapsed < processing_lag)
+                guac_vnc_msleep(processing_lag - time_elapsed);
 
-            /* Wait again if frame remaining */
-            if (frame_remaining > 0)
-                wait_result = WaitForMessage(rfb_client, GUAC_VNC_FRAME_TIMEOUT*1000);
-            else
-                break;
+            /* Read server messages until frame is built */
+            do {
+
+                guac_timestamp frame_end;
+                int frame_remaining;
+
+                /* Handle any message received */
+                if (!HandleRFBServerMessage(rfb_client)) {
+                    guac_client_abort(client,
+                            GUAC_PROTOCOL_STATUS_UPSTREAM_ERROR,
+                            "Error handling message from VNC server.");
+                    break;
+                }
+
+                /* Calculate time remaining in frame */
+                frame_end = guac_timestamp_current();
+                frame_remaining = frame_start + GUAC_VNC_FRAME_DURATION
+                                - frame_end;
+
+                /* Wait again if frame remaining */
+                if (frame_remaining > 0)
+                    wait_result = WaitForMessage(rfb_client,
+                            GUAC_VNC_FRAME_TIMEOUT*1000);
+                else
+                    break;
+
+            } while (wait_result > 0);
+
+            /* Record end of frame */
+            last_frame_end = guac_timestamp_current();
 
         }
 


### PR DESCRIPTION
This change adds lag statistics to the ```guac_user``` structure, and automatically updates them as ```sync``` instructions are received from connected users. Client plugins can then use ```guac_client_get_processing_lag()``` to approximate the processing lag experienced by the connected pool of users, and adjust server-side frame duration accordingly.

The VNC client had been updated to use ```guac_client_get_processing_lag()``` appropriately.