### PR TITLE
GUAC-803: Add mouse support to scrollbar

### DIFF
--- a/src/terminal/Makefile.am
+++ b/src/terminal/Makefile.am
@@ -34,6 +34,7 @@ noinst_HEADERS =                \
     cursor.h                    \
     display.h                   \
     ibar.h                      \
+    pointer.h                   \
     scrollbar.h                 \
     terminal.h                  \
     terminal_handlers.h         \
@@ -47,6 +48,7 @@ libguac_terminal_la_SOURCES =   \
     cursor.c                    \
     display.c                   \
     ibar.c                      \
+    pointer.c                   \
     scrollbar.c                 \
     terminal.c                  \
     terminal_handlers.c

--- a/src/terminal/pointer.c
+++ b/src/terminal/pointer.c
@@ -1,0 +1,94 @@
+/*
+ * Copyright (C) 2015 Glyptodon LLC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "config.h"
+
+#include "cursor.h"
+
+#include <cairo/cairo.h>
+#include <guacamole/client.h>
+#include <guacamole/protocol.h>
+#include <guacamole/socket.h>
+
+/* Macros for prettying up the embedded image. */
+#define X 0x00,0x00,0x00,0xFF
+#define U 0x80,0x80,0x80,0xFF
+#define O 0xFF,0xFF,0xFF,0xFF
+#define _ 0x00,0x00,0x00,0x00
+
+/* Dimensions */
+const int guac_terminal_pointer_width  = 11;
+const int guac_terminal_pointer_height = 16;
+
+/* Format */
+const cairo_format_t guac_terminal_pointer_format = CAIRO_FORMAT_ARGB32;
+const int guac_terminal_pointer_stride = 44;
+
+/* Embedded pointer graphic */
+unsigned char guac_terminal_pointer[] = {
+
+        O,_,_,_,_,_,_,_,_,_,_,
+        O,O,_,_,_,_,_,_,_,_,_,
+        O,X,O,_,_,_,_,_,_,_,_,
+        O,X,X,O,_,_,_,_,_,_,_,
+        O,X,X,X,O,_,_,_,_,_,_,
+        O,X,X,X,X,O,_,_,_,_,_,
+        O,X,X,X,X,X,O,_,_,_,_,
+        O,X,X,X,X,X,X,O,_,_,_,
+        O,X,X,X,X,X,X,X,O,_,_,
+        O,X,X,X,X,X,X,X,X,O,_,
+        O,X,X,X,X,X,O,O,O,O,O,
+        O,X,X,O,X,X,O,_,_,_,_,
+        O,X,O,_,O,X,X,O,_,_,_,
+        O,O,_,_,O,X,X,O,_,_,_,
+        O,_,_,_,_,O,X,X,O,_,_,
+        _,_,_,_,_,O,O,O,O,_,_
+
+};
+
+guac_terminal_cursor* guac_terminal_create_pointer(guac_client* client) {
+
+    guac_socket* socket = client->socket;
+    guac_terminal_cursor* cursor = guac_terminal_cursor_alloc(client);
+
+    /* Draw to buffer */
+    cairo_surface_t* graphic = cairo_image_surface_create_for_data(
+            guac_terminal_pointer,
+            guac_terminal_pointer_format,
+            guac_terminal_pointer_width,
+            guac_terminal_pointer_height,
+            guac_terminal_pointer_stride);
+
+    guac_protocol_send_png(socket, GUAC_COMP_SRC, cursor->buffer,
+            0, 0, graphic);
+    cairo_surface_destroy(graphic);
+
+    /* Initialize cursor properties */
+    cursor->width = guac_terminal_pointer_width;
+    cursor->height = guac_terminal_pointer_height;
+    cursor->hotspot_x = 0;
+    cursor->hotspot_y = 0;
+
+    return cursor;
+
+}
+

--- a/src/terminal/pointer.h
+++ b/src/terminal/pointer.h
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2015 Glyptodon LLC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+
+#ifndef GUAC_TERMINAL_POINTER_H
+#define GUAC_TERMINAL_POINTER_H
+
+#include "config.h"
+
+#include <cairo/cairo.h>
+#include <guacamole/client.h>
+
+/**
+ * Width of the embedded mouse cursor graphic.
+ */
+extern const int guac_terminal_pointer_width;
+
+/**
+ * Height of the embedded mouse cursor graphic.
+ */
+extern const int guac_terminal_pointer_height;
+
+/**
+ * Number of bytes in each row of the embedded mouse cursor graphic.
+ */
+extern const int guac_terminal_pointer_stride;
+
+/**
+ * The Cairo grapic format of the mouse cursor graphic.
+ */
+extern const cairo_format_t guac_terminal_pointer_format;
+
+/**
+ * Embedded mouse cursor graphic.
+ */
+extern unsigned char guac_terminal_pointer[];
+
+/**
+ * Creates a new pointer cursor, returning the corresponding cursor object.
+ *
+ * @param client
+ *     The guac_client to send the cursor to.
+ *
+ * @return
+ *     A new cursor which must be free'd via guac_terminal_cursor_free().
+ */
+guac_terminal_cursor* guac_terminal_create_pointer(guac_client* client);
+
+#endif

--- a/src/terminal/scrollbar.c
+++ b/src/terminal/scrollbar.c
@@ -213,14 +213,8 @@ void guac_terminal_scrollbar_flush(guac_terminal_scrollbar* scrollbar) {
     calculate_state(scrollbar, &new_state, &new_value);
 
     /* Notify of scroll if value is changing */
-    if (new_value != old_value) {
-
-        /* TODO: Call scroll value handler */
-        guac_client_log(scrollbar->client, GUAC_LOG_DEBUG,
-                "SCROLL: min=%i max=%i value=%i",
-                scrollbar->min, scrollbar->max, new_value);
-
-    }
+    if (new_value != old_value && scrollbar->scroll_handler)
+        scrollbar->scroll_handler(scrollbar, new_value);
 
     /* Reposition container if moved */
     if (old_state->container_x != new_state.container_x

--- a/src/terminal/scrollbar.h
+++ b/src/terminal/scrollbar.h
@@ -159,6 +159,24 @@ typedef struct guac_terminal_scrollbar {
      */
     guac_terminal_scrollbar_render_state render_state;
 
+    /**
+     * Whether the scrollbar handle is currently being dragged.
+     */
+    int dragging_handle;
+
+    /**
+     * The offset of the Y location of the mouse pointer when the dragging
+     * began, relative to the top of the scrollbar handle. If dragging is not
+     * in progress, this value is undefined.
+     */
+    int drag_offset_y;
+
+    /**
+     * The current Y location of the mouse pointer if dragging is in progress.
+     * If dragging is not in progress, this value is undefined.
+     */
+    int drag_current_y;
+
 } guac_terminal_scrollbar;
 
 /**
@@ -275,5 +293,30 @@ void guac_terminal_scrollbar_set_value(guac_terminal_scrollbar* scrollbar,
  */
 void guac_terminal_scrollbar_parent_resized(guac_terminal_scrollbar* scrollbar,
         int parent_width, int parent_height, int visible_area);
+
+/**
+ * Notifies the scrollbar of the current mouse state, allowing it to update
+ * itself with respect to button state and dragging.
+ *
+ * @param scrollbar
+ *     The scrollbar to notify of the current mouse state.
+ *
+ * @param x
+ *     The X coordinate of the mouse pointer.
+ *
+ * @param y
+ *     The Y coordinate of the mouse pointer.
+ *
+ * @param mask
+ *     The button mask, where the Nth bit of the button mask represents the
+ *     pressed state of the Nth mouse button, where button 0 is the left
+ *     mouse button, button 1 is the middle button, etc.
+ *
+ * @return
+ *     Zero if the mouse event was not handled by the scrollbar, non-zero
+ *     otherwise.
+ */
+int guac_terminal_scrollbar_handle_mouse(guac_terminal_scrollbar* scrollbar,
+        int x, int y, int mask);
 
 #endif

--- a/src/terminal/scrollbar.h
+++ b/src/terminal/scrollbar.h
@@ -96,12 +96,21 @@ typedef struct guac_terminal_scrollbar_render_state {
 
 } guac_terminal_scrollbar_render_state;
 
+typedef struct guac_terminal_scrollbar guac_terminal_scrollbar;
+
+/**
+ * Handler which is called whenever the scrollbar value changes outside a call
+ * to guac_terminal_scrollbar_set_value().
+ */
+typedef void guac_terminal_scrollbar_scroll_handler(
+        guac_terminal_scrollbar* scrollbar, int value);
+
 /**
  * A scrollbar, made up of a containing layer and inner draggable handle. The
  * position of the handle within the layer represents the value of the
  * scrollbar.
  */
-typedef struct guac_terminal_scrollbar {
+struct guac_terminal_scrollbar {
 
     /**
      * The client associated with this scrollbar.
@@ -177,7 +186,18 @@ typedef struct guac_terminal_scrollbar {
      */
     int drag_current_y;
 
-} guac_terminal_scrollbar;
+    /**
+     * The function to call when the scrollbar handle is being dragged, and
+     * the new scrollbar value needs to be handled and assigned.
+     */
+    guac_terminal_scrollbar_scroll_handler* scroll_handler;
+
+    /**
+     * Arbitrary reference to data related to this scrollbar.
+     */
+    void* data;
+
+};
 
 /**
  * Allocates a new scrollbar, associating that scrollbar with the given client

--- a/src/terminal/terminal.c
+++ b/src/terminal/terminal.c
@@ -264,6 +264,10 @@ guac_terminal* guac_terminal_create(guac_client* client,
     term->scrollbar = guac_terminal_scrollbar_alloc(term->client,
             GUAC_DEFAULT_LAYER, width, height, term->term_height);
 
+    /* Associate scrollbar with this terminal */
+    term->scrollbar->data = term;
+    term->scrollbar->scroll_handler = guac_terminal_scroll_handler;
+
     /* Init terminal */
     guac_terminal_reset(term);
 
@@ -1469,6 +1473,24 @@ int guac_terminal_send_mouse(guac_terminal* term, int x, int y, int mask) {
     guac_terminal_unlock(term);
 
     return result;
+
+}
+
+void guac_terminal_scroll_handler(guac_terminal_scrollbar* scrollbar, int value) {
+
+    guac_terminal* terminal = (guac_terminal*) scrollbar->data;
+
+    /* Calculate change in scroll offset */
+    int delta = -value - terminal->scroll_offset;
+
+    /* Update terminal based on change in scroll offset */
+    if (delta < 0)
+        guac_terminal_scroll_display_down(terminal, -delta);
+    else if (delta > 0)
+        guac_terminal_scroll_display_up(terminal, delta);
+
+    /* Update scrollbar value */
+    guac_terminal_scrollbar_set_value(scrollbar, value);
 
 }
 

--- a/src/terminal/terminal.h
+++ b/src/terminal/terminal.h
@@ -308,6 +308,11 @@ struct guac_terminal {
     int mouse_mask;
 
     /**
+     * The cached pointer cursor.
+     */
+    guac_terminal_cursor* pointer_cursor;
+
+    /**
      * The cached I-bar cursor.
      */
     guac_terminal_cursor* ibar_cursor;

--- a/src/terminal/terminal.h
+++ b/src/terminal/terminal.h
@@ -389,6 +389,19 @@ int guac_terminal_send_key(guac_terminal* term, int keysym, int pressed);
 int guac_terminal_send_mouse(guac_terminal* term, int x, int y, int mask);
 
 /**
+ * Handles a scroll event received from the scrollbar associated with a
+ * terminal.
+ *
+ * @param scrollbar
+ *     The scrollbar that has been scrolled.
+ *
+ * @param value
+ *     The new value that should be stored within the scrollbar, and
+ *     represented within the terminal display.
+ */
+void guac_terminal_scroll_handler(guac_terminal_scrollbar* scrollbar, int value);
+
+/**
  * Clears the current clipboard contents and sets the mimetype for future
  * contents.
  */


### PR DESCRIPTION
This change adds mouse support to the existing scrollbar, allowing the current scroll offset to be updated via clicking and dragging the scrollbar handle. The mouse cursor is updated appropriately when over the scrollbar.