### PR TITLE
GUAC-803: Make terminal updates more efficient

### DIFF
--- a/src/terminal/Makefile.am
+++ b/src/terminal/Makefile.am
@@ -34,6 +34,7 @@ noinst_HEADERS =                \
     cursor.h                    \
     display.h                   \
     ibar.h                      \
+    packet.h                    \
     pointer.h                   \
     scrollbar.h                 \
     terminal.h                  \
@@ -48,6 +49,7 @@ libguac_terminal_la_SOURCES =   \
     cursor.c                    \
     display.c                   \
     ibar.c                      \
+    packet.c                    \
     pointer.c                   \
     scrollbar.c                 \
     terminal.c                  \

--- a/src/terminal/common.c
+++ b/src/terminal/common.c
@@ -108,3 +108,23 @@ int guac_terminal_write_all(int fd, const char* buffer, int size) {
 
 }
 
+int guac_terminal_fill_buffer(int fd, char* buffer, int size) {
+
+    int remaining = size;
+    while (remaining > 0) {
+
+        /* Attempt to read data */
+        int ret_val = read(fd, buffer, remaining);
+        if (ret_val <= 0)
+            return -1;
+
+        /* If successful, continue with what space remains (if any) */
+        remaining -= ret_val;
+        buffer += ret_val;
+
+    }
+
+    return size;
+
+}
+

--- a/src/terminal/common.h
+++ b/src/terminal/common.h
@@ -52,5 +52,26 @@ bool guac_terminal_has_glyph(int codepoint);
  */
 int guac_terminal_write_all(int fd, const char* buffer, int size);
 
+/**
+ * Similar to read, but automatically retries the read until an error occurs,
+ * filling all available space within the buffer. Unless it is known that the
+ * given amount of space is available on the file descriptor, there is a good
+ * chance this function will block.
+ *
+ * @param fd
+ *     The file descriptor to read data from.
+ *
+ * @param buffer
+ *     The buffer to store data within.
+ *
+ * @param size
+ *     The number of bytes available within the buffer.
+ *
+ * @return
+ *     The number of bytes read if successful, or a negative value if an error
+ *     occurs.
+ */
+int guac_terminal_fill_buffer(int fd, char* buffer, int size);
+
 #endif
 

--- a/src/terminal/packet.c
+++ b/src/terminal/packet.c
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2015 Glyptodon LLC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "common.h"
+#include "packet.h"
+
+#include <string.h>
+
+int guac_terminal_packet_write(int fd, const void* data, int length) {
+
+    guac_terminal_packet out;
+
+    /* Do not attempt to write packets beyond maximum size */
+    if (length > GUAC_TERMINAL_PACKET_SIZE)
+        return -1;
+
+    /* Calculate final packet length */
+    int packet_length = sizeof(int) + length;
+
+    /* Copy data into packet */
+    out.length = length;
+    memcpy(out.data, data, length);
+
+    /* Write packet */
+    return guac_terminal_write_all(fd, (const char*) &out, packet_length);
+
+}
+
+int guac_terminal_packet_read(int fd, void* data, int length) {
+
+    int bytes;
+
+    /* Read buffers MUST be at least GUAC_TERMINAL_PACKET_SIZE */
+    if (length < GUAC_TERMINAL_PACKET_SIZE)
+        return -1;
+
+    /* Read length */
+    if (guac_terminal_fill_buffer(fd, (char*) &bytes, sizeof(int)) < 0)
+        return -1;
+
+    /* Read body */
+    if (guac_terminal_fill_buffer(fd, (char*) data, bytes) < 0)
+        return -1;
+
+    return bytes;
+
+}
+

--- a/src/terminal/packet.h
+++ b/src/terminal/packet.h
@@ -1,0 +1,92 @@
+/*
+ * Copyright (C) 2015 Glyptodon LLC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef GUAC_TERMINAL_PACKET_H
+#define GUAC_TERMINAL_PACKET_H
+
+/**
+ * The maximum size of a packet written or read by the
+ * guac_terminal_packet_write() or guac_terminal_packet_read() functions.
+ */
+#define GUAC_TERMINAL_PACKET_SIZE 4096
+
+/**
+ * An arbitrary data packet with minimal framing.
+ */
+typedef struct guac_terminal_packet {
+
+    /**
+     * The number of bytes in the data portion of this packet.
+     */
+    int length;
+
+    /**
+     * Arbitrary data.
+     */
+    char data[GUAC_TERMINAL_PACKET_SIZE];
+
+} guac_terminal_packet;
+
+/**
+ * Writes a single packet of data to the given file descriptor. The provided
+ * length MUST be no greater than GUAC_TERMINAL_PACKET_SIZE. Zero-length
+ * writes are legal and do result in a packet being written to the file
+ * descriptor.
+ *
+ * @param fd
+ *     The file descriptor to write to.
+ *
+ * @param data
+ *     A buffer containing the data to write.
+ *
+ * @param length
+ *     The number of bytes to write to the file descriptor.
+ *
+ * @return
+ *     The number of bytes written on success, which may be zero if the data
+ *     length is zero, or a negative value on error.
+ */
+int guac_terminal_packet_write(int fd, const void* data, int length);
+
+/**
+ * Reads a single packet of data from the given file descriptor. The provided
+ * length MUST be at least GUAC_TERMINAL_PACKET_SIZE to ensure any packet
+ * read will fit in the buffer. Zero-length reads are possible if a zero-length
+ * packet was written.
+ *
+ * @param fd
+ *     The file descriptor to read from.
+ *
+ * @param data
+ *     The buffer to store data within.
+ *
+ * @param length
+ *     The number of bytes available within the buffer.
+ *
+ * @return
+ *     The number of bytes read on success, which may be zero if the read
+ *     packet had a length of zero, or a negative value on error.
+ */
+int guac_terminal_packet_read(int fd, void* data, int length);
+
+#endif
+

--- a/src/terminal/terminal.h
+++ b/src/terminal/terminal.h
@@ -40,6 +40,17 @@
 #include <guacamole/stream.h>
 
 /**
+ * The maximum duration of a single frame, in milliseconds.
+ */
+#define GUAC_TERMINAL_FRAME_DURATION 40
+
+/**
+ * The maximum amount of time to wait for more data before declaring a frame
+ * complete, in milliseconds.
+ */
+#define GUAC_TERMINAL_FRAME_TIMEOUT 10
+
+/**
  * The maximum number of custom tab stops.
  */
 #define GUAC_TERMINAL_MAX_TABS       16

--- a/src/terminal/terminal.h
+++ b/src/terminal/terminal.h
@@ -368,6 +368,19 @@ int guac_terminal_read_stdin(guac_terminal* terminal, char* c, int size);
 int guac_terminal_write_stdout(guac_terminal* terminal, const char* c, int size);
 
 /**
+ * Notifies the terminal that an event has occurred and the terminal should
+ * flush itself when reasonable.
+ *
+ * @param terminal
+ *     The terminal to notify.
+ *
+ * @return
+ *     Zero if notification succeeded, non-zero if an error occurred while
+ *     notifying the terminal.
+ */
+int guac_terminal_notify(guac_terminal* terminal);
+
+/**
  * Reads a single line from this terminal's STDIN. Input is retrieved in
  * the same manner as guac_terminal_read_stdin() and the same restrictions
  * apply.


### PR DESCRIPTION
The old terminal code would redraw unnecessarily frequently for changes to the display not initiated by data received over STDOUT. This change allows external code to notify the terminal of non-STDOUT changes, thereby unblocking the pending frame and causing a flush, grouping changes as much as possible.