### PR TITLE
GUAC-1005: Include libfreerdp-core in test for freerdp_channels_new()

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -400,14 +400,15 @@ then
                  [RDP_LIBS="$RDP_LIBS -lfreerdp-cache"])
 fi
 
-# libfreerdp-channels (1.0) / libfreerdp-client (1.1)
+# libfreerdp-channels (1.0) / libfreerdp-client + libfreerdp-core (1.1)
 if test "x${have_freerdp}" = "xyes"
 then
     AC_CHECK_LIB([freerdp-client], [freerdp_channels_new],
                  [RDP_LIBS="$RDP_LIBS -lfreerdp-client"],
                  [AC_CHECK_LIB([freerdp-channels], [freerdp_channels_new],
                                [RDP_LIBS="$RDP_LIBS -lfreerdp-channels"
-                               legacy_freerdp_extensions=yes])])
+                               legacy_freerdp_extensions=yes])],
+                 [-lfreerdp-core])
 fi
 
 # libfreerdp-utils


### PR DESCRIPTION
The ```freerdp_channels_new()``` function is not always included in libfreerdp-client, depending on the FreeRDP version in question, and its absence can result in libfreerdp-client not being linked in if:

1. The platform on which guacamole-server is built (correctly) does not automatically link against implied dependencies ([Fedora](http://fedoraproject.org/wiki/Features/ChangeInImplicitDSOLinking), for example).
2. The FreeRDP version puts ```freerdp_channels_new()``` in libfreerdp-core instead of libfreerdp-client.