### PR TITLE
GUAC-1018: Update guacamole-server for 0.9.5 release.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -8,3 +8,4 @@ Laurent Meunier <laurent@deltalima.net>
 Saul Gio Perez <gio.perez@sv.cmu.edu>
 Tom Sealy <tom.sealy@yahoo.com>
 Felipe Weckx <felipe@weckx.net>
+Ruggero Vecchio <ruggero.vecchio@datev.it>

--- a/configure.ac
+++ b/configure.ac
@@ -21,7 +21,7 @@
 #
 
 AC_PREREQ([2.61])
-AC_INIT([guacamole-server], [0.9.4])
+AC_INIT([guacamole-server], [0.9.5])
 AM_INIT_AUTOMAKE([-Wall -Werror foreign subdir-objects])
 AM_SILENT_RULES([yes])
 

--- a/doc/Doxyfile
+++ b/doc/Doxyfile
@@ -31,7 +31,7 @@ PROJECT_NAME           = libguac
 # This could be handy for archiving the generated documentation or
 # if some version control system is used.
 
-PROJECT_NUMBER         = 0.9.4
+PROJECT_NUMBER         = 0.9.5
 
 # The OUTPUT_DIRECTORY tag is used to specify the (relative or absolute)
 # base path where the generated documentation will be put.

--- a/src/guacd/man/guacd.8
+++ b/src/guacd/man/guacd.8
@@ -1,4 +1,4 @@
-.TH guacd 8 "6 Jan 2015" "version 0.9.4" "Guacamole"
+.TH guacd 8 "6 Jan 2015" "version 0.9.5" "Guacamole"
 .
 .SH NAME
 guacd \- Guacamole proxy daemon

--- a/src/guacd/man/guacd.conf.5
+++ b/src/guacd/man/guacd.conf.5
@@ -1,4 +1,4 @@
-.TH guacd.conf 5 "6 Jan 2015" "version 0.9.4" "Guacamole"
+.TH guacd.conf 5 "6 Jan 2015" "version 0.9.5" "Guacamole"
 .
 .SH NAME
 /etc/guacamole/guacd.conf \- Configuration file for guacd


### PR DESCRIPTION
This change brings guacamole-server up to date with respect to new contributors, and bumps the version number of the project.

Unlike 0.9.4, no changes at all were made to libguac, so the libtool versioning is untouched. A 0.9.4 build of libguac will be completely identical to a 0.9.5 build of libguac.