### PR TITLE
GUAC-1090: Clip operation by surface size when no clipping rectangle is present.

### DIFF
--- a/src/common/guac_surface.c
+++ b/src/common/guac_surface.c
@@ -122,9 +122,11 @@ static void __guac_common_clip_rect(guac_common_surface* surface,
     int orig_x = rect->x;
     int orig_y = rect->y;
 
-    /* Skip clipping if no clipping rectangle applied */
-    if (!surface->clipped)
+    /* Just bound within surface if no clipping rectangle applied */
+    if (!surface->clipped) {
+        __guac_common_bound_rect(surface, rect, sx, sy);
         return;
+    }
 
     guac_common_rect_constrain(rect, &surface->clip_rect);
 


### PR DESCRIPTION
A long series of changes has resulted in RDP updates *not* being clipped within surface bounds unless an explicit clipping rectangle is present. This change ensures that all updates are clipped within surface bounds, regardless of the presence or absence of a clipping rectangle.