### PR TITLE
GUAC-1095: Free any existing bitmap data prior to overwriting the bitmap data pointer.

### DIFF
--- a/src/protocols/rdp/rdp_bitmap.c
+++ b/src/protocols/rdp/rdp_bitmap.c
@@ -201,8 +201,17 @@ void guac_rdp_bitmap_decompress(rdpContext* context, rdpBitmap* bitmap, UINT8* d
     int size = width * height * 4;
 
 #ifdef FREERDP_BITMAP_REQUIRES_ALIGNED_MALLOC
+    /* Free pre-existing data, if any (might be reused) */
+    if (bitmap->data != NULL)
+        _aligned_free(bitmap->data);
+
+    /* Allocate new data */
     bitmap->data = (UINT8*) _aligned_malloc(size, 16);
 #else
+    /* Free pre-existing data, if any (might be reused) */
+    free(bitmap->data);
+
+    /* Allocate new data */
     bitmap->data = (UINT8*) malloc(size);
 #endif
 


### PR DESCRIPTION
When FreeRDP receives a bitmap update from the RDP server, it calls a supplied decompression function to handle decompression and assign the resulting data to the ```bitmap->data``` pointer. FreeRDP will also occasionally reuse past bitmap cache entries. This is all fine.

Unfortunately, the bitmap free function supplied by the implementation is only invoked *after* decompression. This will properly result in implementation-specific data being freed, but since the decompression function *must* assign to ```bitmap->data``` by definition, a memory leak will result if that decompression function does not also free anything already in ```bitmap->data```.