### PR TITLE
GUAC-1167: File download using RDP protocol via xrdp does not work

### DIFF
--- a/src/protocols/rdp/rdp_fs.c
+++ b/src/protocols/rdp/rdp_fs.c
@@ -176,7 +176,7 @@ int guac_rdp_fs_open(guac_rdp_fs* fs, const char* path,
         path = "\\";
 
     /* If path is relative, the file does not exist */
-    else if (path[0] != '\\') {
+    else if (path[0] != '\\' && path[0] != '/') {
         guac_client_log(fs->client, GUAC_LOG_DEBUG,
                 "%s: Access denied - supplied path \"%s\" is relative.",
                 __func__, path);


### PR DESCRIPTION
This one-liner fix ensures that a target machine running XRDP 0.9.0, which supports drive redirection, can handle file downloads from the virtual "Downloads" folder.  Otherwise, the download from target machine to browser does not work.