### PR TITLE
GUAC-1174: Bump version numbers to 0.9.7.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -21,7 +21,7 @@
 #
 
 AC_PREREQ([2.61])
-AC_INIT([guacamole-server], [0.9.6])
+AC_INIT([guacamole-server], [0.9.7])
 AM_INIT_AUTOMAKE([-Wall -Werror foreign subdir-objects])
 AM_SILENT_RULES([yes])
 

--- a/doc/Doxyfile
+++ b/doc/Doxyfile
@@ -31,7 +31,7 @@ PROJECT_NAME           = libguac
 # This could be handy for archiving the generated documentation or
 # if some version control system is used.
 
-PROJECT_NUMBER         = 0.9.6
+PROJECT_NUMBER         = 0.9.7
 
 # The OUTPUT_DIRECTORY tag is used to specify the (relative or absolute)
 # base path where the generated documentation will be put.


### PR DESCRIPTION
No changes to libguac this time. Only RDP and VNC were affected by this release.