### PR TITLE
GUAC-1172: Implement libguac side of Guacamole protocol objects.

### DIFF
--- a/src/libguac/Makefile.am
+++ b/src/libguac/Makefile.am
@@ -41,6 +41,8 @@ libguacinc_HEADERS =                  \
     guacamole/instruction-types.h     \
     guacamole/layer.h                 \
     guacamole/layer-types.h           \
+    guacamole/object.h                \
+    guacamole/object-types.h          \
     guacamole/plugin-constants.h      \
     guacamole/plugin.h                \
     guacamole/plugin-types.h          \

--- a/src/libguac/client-handlers.h
+++ b/src/libguac/client-handlers.h
@@ -123,6 +123,20 @@ int __guac_handle_blob(guac_client* client, guac_instruction* instruction);
 int __guac_handle_end(guac_client* client, guac_instruction* instruction);
 
 /**
+ * Internal initial handler for the get instruction. When a get instruction
+ * is received, this handler will be called. The client's get handler will
+ * be invoked if defined.
+ */
+int __guac_handle_get(guac_client* client, guac_instruction* instruction);
+
+/**
+ * Internal initial handler for the put instruction. When a put instruction
+ * is received, this handler will be called. The client's put handler will
+ * be invoked if defined.
+ */
+int __guac_handle_put(guac_client* client, guac_instruction* instruction);
+
+/**
  * Internal initial handler for the size instruction. When a size instruction
  * is received, this handler will be called. The client's size handler will
  * be invoked if defined.

--- a/src/libguac/client.c
+++ b/src/libguac/client.c
@@ -27,6 +27,7 @@
 #include "error.h"
 #include "instruction.h"
 #include "layer.h"
+#include "object.h"
 #include "pool.h"
 #include "protocol.h"
 #include "socket.h"
@@ -216,7 +217,7 @@ guac_client* guac_client_alloc() {
     /* Allocate stream pool */
     client->__stream_pool = guac_pool_alloc(0);
 
-    /* Initialze streams */
+    /* Initialize streams */
     client->__input_streams = malloc(sizeof(guac_stream) * GUAC_CLIENT_MAX_STREAMS);
     client->__output_streams = malloc(sizeof(guac_stream) * GUAC_CLIENT_MAX_STREAMS);
 
@@ -224,6 +225,11 @@ guac_client* guac_client_alloc() {
         client->__input_streams[i].index = GUAC_CLIENT_CLOSED_STREAM_INDEX;
         client->__output_streams[i].index = GUAC_CLIENT_CLOSED_STREAM_INDEX;
     }
+
+    /* Initialize objects */
+    client->__objects = malloc(sizeof(guac_object) * GUAC_CLIENT_MAX_OBJECTS);
+    for (i=0; i<GUAC_CLIENT_MAX_OBJECTS; i++)
+        client->__objects[i].index = GUAC_CLIENT_UNDEFINED_OBJECT_INDEX;
 
     return client;
 
@@ -245,6 +251,9 @@ void guac_client_free(guac_client* client) {
     /* Free streams */
     free(client->__input_streams);
     free(client->__output_streams);
+
+    /* Free objects */
+    free(client->__objects);
 
     /* Free stream pool */
     guac_pool_free(client->__stream_pool);

--- a/src/libguac/guacamole/client-constants.h
+++ b/src/libguac/guacamole/client-constants.h
@@ -50,6 +50,18 @@
 #define GUAC_CLIENT_UNDEFINED_OBJECT_INDEX -1
 
 /**
+ * The stream name reserved for the root of a Guacamole protocol object.
+ */
+#define GUAC_CLIENT_OBJECT_ROOT_NAME "/"
+
+/**
+ * The mimetype of a stream containing a map of available stream names to their
+ * corresponding mimetypes. The root of a Guacamole protocol object is
+ * guaranteed to have this type.
+ */
+#define GUAC_CLIENT_STREAM_INDEX_MIMETYPE "application/vnd.glyptodon.guacamole.stream-index+json"
+
+/**
  * The flag set in the mouse button mask when the left mouse button is down.
  */
 #define GUAC_CLIENT_MOUSE_LEFT 0x01

--- a/src/libguac/guacamole/client-constants.h
+++ b/src/libguac/guacamole/client-constants.h
@@ -40,6 +40,16 @@
 #define GUAC_CLIENT_CLOSED_STREAM_INDEX -1
 
 /**
+ * The maximum number of objects supported by any one guac_client.
+ */
+#define GUAC_CLIENT_MAX_OBJECTS 64
+
+/**
+ * The index of an object which has not been defined.
+ */
+#define GUAC_CLIENT_UNDEFINED_OBJECT_INDEX -1
+
+/**
  * The flag set in the mouse button mask when the left mouse button is down.
  */
 #define GUAC_CLIENT_MOUSE_LEFT 0x01

--- a/src/libguac/guacamole/client-fntypes.h
+++ b/src/libguac/guacamole/client-fntypes.h
@@ -31,6 +31,7 @@
  */
 
 #include "client-types.h"
+#include "object-types.h"
 #include "protocol-types.h"
 #include "stream-types.h"
 
@@ -91,6 +92,18 @@ typedef int guac_client_ack_handler(guac_client* client, guac_stream* stream,
  * Handler for Guacamole stream end events.
  */
 typedef int guac_client_end_handler(guac_client* client, guac_stream* stream);
+
+/**
+ * Handler for Guacamole object get events.
+ */
+typedef int guac_client_get_handler(guac_client* client, guac_object* object,
+        char* name);
+
+/**
+ * Handler for Guacamole object put events.
+ */
+typedef int guac_client_put_handler(guac_client* client, guac_object* object,
+        guac_stream* stream, char* mimetype, char* name);
 
 /**
  * Handler for Guacamole audio format events.

--- a/src/libguac/guacamole/client.h
+++ b/src/libguac/guacamole/client.h
@@ -34,6 +34,7 @@
 #include "client-constants.h"
 #include "instruction-types.h"
 #include "layer-types.h"
+#include "object-types.h"
 #include "pool-types.h"
 #include "socket-types.h"
 #include "stream-types.h"
@@ -367,6 +368,46 @@ struct guac_client {
     guac_client_log_handler* log_handler;
 
     /**
+     * Handler for get events sent by the Guacamole web-client.
+     *
+     * The handler takes a guac_object, containing the object index which will
+     * persist through the duration of the transfer, and the name of the stream
+     * being requested. It is up to the get handler to create the required body
+     * stream.
+     *
+     * Example:
+     * @code
+     *     int get_handler(guac_client* client, guac_object* object,
+     *             char* name);
+     *
+     *     int guac_client_init(guac_client* client, int argc, char** argv) {
+     *         client->get_handler = get_handler;
+     *     }
+     * @endcode
+     */
+    guac_client_get_handler* get_handler;
+
+    /**
+     * Handler for put events sent by the Guacamole web-client.
+     *
+     * The handler takes a guac_object and guac_stream, which each contain their
+     * respective indices which will persist through the duration of the
+     * transfer, the mimetype of the data being transferred, and the name of
+     * the stream within the object being written to.
+     *
+     * Example:
+     * @code
+     *     int put_handler(guac_client* client, guac_object* object,
+     *             guac_stream* stream, char* mimetype, char* name);
+     *
+     *     int guac_client_init(guac_client* client, int argc, char** argv) {
+     *         client->put_handler = put_handler;
+     *     }
+     * @endcode
+     */
+    guac_client_put_handler* put_handler;
+
+    /**
      * Pool of buffer indices. Buffers are simply layers with negative indices.
      * Note that because guac_pool always gives non-negative indices starting
      * at 0, the output of this guac_pool will be adjusted.
@@ -394,6 +435,11 @@ struct guac_client {
      * All available input streams (data coming from connected client).
      */
     guac_stream* __input_streams;
+
+    /**
+     * All available objects (arbitrary sets of named streams).
+     */
+    guac_object* __objects;
 
     /**
      * The unique identifier allocated for the connection, which may

--- a/src/libguac/guacamole/client.h
+++ b/src/libguac/guacamole/client.h
@@ -437,6 +437,11 @@ struct guac_client {
     guac_stream* __input_streams;
 
     /**
+     * Pool of object indices.
+     */
+    guac_pool* __object_pool;
+
+    /**
      * All available objects (arbitrary sets of named streams).
      */
     guac_object* __objects;

--- a/src/libguac/guacamole/client.h
+++ b/src/libguac/guacamole/client.h
@@ -604,6 +604,30 @@ guac_stream* guac_client_alloc_stream(guac_client* client);
 void guac_client_free_stream(guac_client* client, guac_stream* stream);
 
 /**
+ * Allocates a new object. An arbitrary index is automatically assigned
+ * if no previously-allocated object is available for use.
+ *
+ * @param client
+ *     The proxy client to allocate the object for.
+ *
+ * @return
+ *     The next available object, or a newly allocated object.
+ */
+guac_object* guac_client_alloc_object(guac_client* client);
+
+/**
+ * Returns the given object to the pool of available objects, such that it
+ * can be reused by any subsequent call to guac_client_alloc_object().
+ *
+ * @param client
+ *     The proxy client to return the object to.
+ *
+ * @param object
+ *     The object to return to the pool of available object.
+ */
+void guac_client_free_object(guac_client* client, guac_object* object);
+
+/**
  * The default Guacamole client layer, layer 0.
  */
 extern const guac_layer* GUAC_DEFAULT_LAYER;

--- a/src/libguac/guacamole/object-types.h
+++ b/src/libguac/guacamole/object-types.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2015 Glyptodon LLC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef GUAC_OBJECT_TYPES_H
+#define GUAC_OBJECT_TYPES_H
+
+/**
+ * Type definitions related to Guacamole protocol objects.
+ *
+ * @file object-types.h
+ */
+
+/**
+ * Represents a single object within the Guacamole protocol.
+ */
+typedef struct guac_object guac_object;
+
+#endif
+

--- a/src/libguac/guacamole/object.h
+++ b/src/libguac/guacamole/object.h
@@ -1,0 +1,96 @@
+/*
+ * Copyright (C) 2015 Glyptodon LLC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef GUAC_OBJECT_H
+#define GUAC_OBJECT_H
+
+/**
+ * Provides functions and structures required for allocating and using objects.
+ *
+ * @file object.h
+ */
+
+#include "client-fntypes.h"
+#include "object-types.h"
+
+struct guac_object {
+
+    /**
+     * The index of this object.
+     */
+    int index;
+
+    /**
+     * Arbitrary data associated with this object.
+     */
+    void* data;
+
+    /**
+     * Handler for get events sent by the Guacamole web-client.
+     *
+     * The handler takes a guac_object, containing the object index which will
+     * persist through the duration of the transfer, and the name of the stream
+     * being requested. It is up to the get handler to create the required body
+     * stream.
+     *
+     * Example:
+     * @code
+     *     int get_handler(guac_client* client, guac_object* object,
+     *             char* name);
+     *
+     *     int some_function(guac_client* client) {
+     *
+     *         guac_object* object = guac_client_alloc_object(client);
+     *         object->get_handler = get_handler;
+     *
+     *     }
+     * @endcode
+     */
+    guac_client_get_handler* get_handler;
+
+    /**
+     * Handler for put events sent by the Guacamole web-client.
+     *
+     * The handler takes a guac_object and guac_stream, which each contain their
+     * respective indices which will persist through the duration of the
+     * transfer, the mimetype of the data being transferred, and the name of
+     * the stream within the object being written to.
+     *
+     * Example:
+     * @code
+     *     int put_handler(guac_client* client, guac_object* object,
+     *             guac_stream* stream, char* mimetype, char* name);
+     *
+     *     int some_function(guac_client* client) {
+     *
+     *         guac_object* object = guac_client_alloc_object(client);
+     *         object->put_handler = put_handler;
+     *
+     *     }
+     * @endcode
+     */
+    guac_client_put_handler* put_handler;
+
+};
+
+#endif
+

--- a/src/libguac/guacamole/protocol.h
+++ b/src/libguac/guacamole/protocol.h
@@ -32,6 +32,7 @@
  */
 
 #include "layer-types.h"
+#include "object-types.h"
 #include "protocol-types.h"
 #include "socket-types.h"
 #include "stream-types.h"
@@ -216,6 +217,75 @@ int guac_protocol_send_select(guac_socket* socket, const char* protocol);
  * @return Zero on success, non-zero on error.
  */
 int guac_protocol_send_sync(guac_socket* socket, guac_timestamp timestamp);
+
+/* OBJECT INSTRUCTIONS */
+
+/**
+ * Sends a body instruction over the given guac_socket connection.
+ *
+ * If an error occurs sending the instruction, a non-zero value is
+ * returned, and guac_error is set appropriately.
+ *
+ * @param socket
+ *     The guac_socket connection to use.
+ *
+ * @param object
+ *     The object to associated with the stream being used.
+ *
+ * @param stream
+ *     The stream to use.
+ *
+ * @param mimetype
+ *     The mimetype of the data being sent.
+ *
+ * @param name
+ *     The name of the stream whose body is being sent, as requested by a "get"
+ *     instruction.
+ *
+ * @return
+ *     Zero on success, non-zero on error.
+ */
+int guac_protocol_send_body(guac_socket* socket, const guac_object* object,
+        const guac_stream* stream, const char* mimetype, const char* name);
+
+/**
+ * Sends a filesystem instruction over the given guac_socket connection.
+ *
+ * If an error occurs sending the instruction, a non-zero value is
+ * returned, and guac_error is set appropriately.
+ *
+ * @param socket
+ *     The guac_socket connection to use.
+ *
+ * @param object
+ *     The object representing the filesystem being exposed.
+ *
+ * @param name
+ *     A name describing the filesystem being exposed.
+ *
+ * @return
+ *     Zero on success, non-zero on error.
+ */
+int guac_protocol_send_filesystem(guac_socket* socket,
+        const guac_object* object, const char* name);
+
+/**
+ * Sends an undefine instruction over the given guac_socket connection.
+ *
+ * If an error occurs sending the instruction, a non-zero value is
+ * returned, and guac_error is set appropriately.
+ *
+ * @param socket
+ *     The guac_socket connection to use.
+ *
+ * @param object
+ *     The object being undefined.
+ *
+ * @return
+ *     Zero on success, non-zero on error.
+ */
+int guac_protocol_send_undefine(guac_socket* socket,
+        const guac_object* object);
 
 /* MEDIA INSTRUCTIONS */
 

--- a/src/libguac/protocol.c
+++ b/src/libguac/protocol.c
@@ -24,6 +24,7 @@
 
 #include "error.h"
 #include "layer.h"
+#include "object.h"
 #include "palette.h"
 #include "protocol.h"
 #include "socket.h"
@@ -463,6 +464,28 @@ int guac_protocol_send_blob(guac_socket* socket, const guac_stream* stream,
 
 }
 
+int guac_protocol_send_body(guac_socket* socket, const guac_object* object,
+        const guac_stream* stream, const char* mimetype, const char* name) {
+
+    int ret_val;
+
+    guac_socket_instruction_begin(socket);
+    ret_val =
+           guac_socket_write_string(socket, "4.body,")
+        || __guac_socket_write_length_int(socket, object->index)
+        || guac_socket_write_string(socket, ",")
+        || __guac_socket_write_length_int(socket, stream->index)
+        || guac_socket_write_string(socket, ",")
+        || __guac_socket_write_length_string(socket, mimetype)
+        || guac_socket_write_string(socket, ",")
+        || __guac_socket_write_length_string(socket, name)
+        || guac_socket_write_string(socket, ";");
+
+    guac_socket_instruction_end(socket);
+    return ret_val;
+
+}
+
 int guac_protocol_send_cfill(guac_socket* socket,
         guac_composite_mode mode, const guac_layer* layer,
         int r, int g, int b, int a) {
@@ -824,6 +847,24 @@ int guac_protocol_send_file(guac_socket* socket, const guac_stream* stream,
         || __guac_socket_write_length_int(socket, stream->index)
         || guac_socket_write_string(socket, ",")
         || __guac_socket_write_length_string(socket, mimetype)
+        || guac_socket_write_string(socket, ",")
+        || __guac_socket_write_length_string(socket, name)
+        || guac_socket_write_string(socket, ";");
+
+    guac_socket_instruction_end(socket);
+    return ret_val;
+
+}
+
+int guac_protocol_send_filesystem(guac_socket* socket,
+        const guac_object* object, const char* name) {
+
+    int ret_val;
+
+    guac_socket_instruction_begin(socket);
+    ret_val =
+           guac_socket_write_string(socket, "10.filesystem,")
+        || __guac_socket_write_length_int(socket, object->index)
         || guac_socket_write_string(socket, ",")
         || __guac_socket_write_length_string(socket, name)
         || guac_socket_write_string(socket, ";");
@@ -1277,6 +1318,22 @@ int guac_protocol_send_transform(guac_socket* socket, const guac_layer* layer,
         || __guac_socket_write_length_double(socket, e)
         || guac_socket_write_string(socket, ",")
         || __guac_socket_write_length_double(socket, f)
+        || guac_socket_write_string(socket, ";");
+
+    guac_socket_instruction_end(socket);
+    return ret_val;
+
+}
+
+int guac_protocol_send_undefine(guac_socket* socket,
+        const guac_object* object) {
+
+    int ret_val;
+
+    guac_socket_instruction_begin(socket);
+    ret_val =
+           guac_socket_write_string(socket, "8.undefine,")
+        || __guac_socket_write_length_int(socket, object->index)
         || guac_socket_write_string(socket, ";");
 
     guac_socket_instruction_end(socket);


### PR DESCRIPTION
To facilitate exposure of entire filesystems, we're adding a new system similar to the existing streaming pattern already part of the Guacamole protocol: objects. A Guacamole protocol object functions as a set of named streams, each of which can be read from or written to by the `get` or `put` instruction respectively.

The `get` and `put` instructions result in the creation of streams within the context of the object. In the case of `put`, the stream is created directly, while the stream in response to a `get` must be created using a `body` instruction. This is in line with the existing stream pattern of the Guacamole protocol, where the side of the conversation sending the data must create the stream, and does so through an instruction which associates an index with metainformation describing the stream being created.

The overall process is thus:

1. Server exposes a filesystem be announcing the existence of a new filesystem object with the `filesystem` instruction.
2. The client can then read from this filesystem with `get`, or write to the filesystem with `put`. Both `get` and `put` designate the stream to be read/written by name. For filesystems, this will be the absolute path of the file.
3. If the client requests data with `get`, the server must respond with `body` to create the outbound stream. In the case of `put`, it is the `put` instruction itself which indicates the creation of an outbound stream from the perspective of the client.
4. When the life of the filesystem object ends, the server indicates this with an `undefine` instruction.

Functions have been provided through this change for:

1. Allocating and freeing objects.
2. Handling `get` and `put` instructions at either the object level or client level.
3. Sending the `filesystem`, `body`, and `undefine` instructions.