### PR TITLE
GUAC-1172: Add filesystem object support to SSH/SFTP.

### DIFF
--- a/src/protocols/ssh/client.c
+++ b/src/protocols/ssh/client.c
@@ -162,6 +162,7 @@ int guac_client_init(guac_client* client, int argc, char** argv) {
     client_data->enable_sftp = strcmp(argv[IDX_ENABLE_SFTP], "true") == 0;
     client_data->sftp_session = NULL;
     client_data->sftp_ssh_session = NULL;
+    client_data->sftp_filesystem = NULL;
     strcpy(client_data->sftp_upload_path, ".");
 
 #ifdef ENABLE_SSH_AGENT

--- a/src/protocols/ssh/client.h
+++ b/src/protocols/ssh/client.h
@@ -132,7 +132,7 @@ typedef struct ssh_guac_client_data {
     /**
      * The filesystem object exposed for the SFTP session.
      */
-    guac_object* filesystem;
+    guac_object* sftp_filesystem;
 
     /**
      * The path files will be sent to, if uploaded directly via a "file"

--- a/src/protocols/ssh/client.h
+++ b/src/protocols/ssh/client.h
@@ -33,6 +33,8 @@
 #include <libssh2.h>
 #include <libssh2_sftp.h>
 
+#include <guacamole/object.h>
+
 #ifdef ENABLE_SSH_AGENT
 #include "ssh_agent.h"
 #endif
@@ -128,7 +130,13 @@ typedef struct ssh_guac_client_data {
     LIBSSH2_SFTP* sftp_session;
 
     /**
-     * The path files will be sent to.
+     * The filesystem object exposed for the SFTP session.
+     */
+    guac_object* filesystem;
+
+    /**
+     * The path files will be sent to, if uploaded directly via a "file"
+     * instruction.
      */
     char sftp_upload_path[GUAC_SFTP_MAX_PATH];
 

--- a/src/protocols/ssh/guac_handlers.c
+++ b/src/protocols/ssh/guac_handlers.c
@@ -101,14 +101,19 @@ int ssh_guac_client_free_handler(guac_client* client) {
     /* Free channels */
     libssh2_channel_free(guac_client_data->term_channel);
 
-    /* Clean up SFTP */
+    /* Shutdown SFTP session, if any */
     if (guac_client_data->sftp_session)
         libssh2_sftp_shutdown(guac_client_data->sftp_session);
 
+    /* Disconnect SSH session corresponding to the SFTP session */
     if (guac_client_data->sftp_ssh_session) {
         libssh2_session_disconnect(guac_client_data->sftp_ssh_session, "Bye");
         libssh2_session_free(guac_client_data->sftp_ssh_session);
     }
+
+    /* Clean up the SFTP filesystem object */
+    if (guac_client_data->sftp_filesystem)
+        guac_client_free_object(client, guac_client_data->sftp_filesystem);
 
     /* Free session */
     if (guac_client_data->session != NULL)

--- a/src/protocols/ssh/sftp.c
+++ b/src/protocols/ssh/sftp.c
@@ -28,10 +28,13 @@
 #include <fcntl.h>
 #include <libgen.h>
 #include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 
 #include <libssh2_sftp.h>
 #include <guacamole/client.h>
+#include <guacamole/object.h>
 #include <guacamole/protocol.h>
 #include <guacamole/socket.h>
 #include <guacamole/stream.h>
@@ -129,7 +132,7 @@ int guac_sftp_file_handler(guac_client* client, guac_stream* stream,
                 client_data->sftp_upload_path, filename)) {
 
         guac_client_log(client, GUAC_LOG_DEBUG,
-                "Filename \"%s/%s\" is invalid or resulting path is too long",
+                "Filename \"%s\" is invalid or resulting path is too long",
                 filename);
 
         /* Abort transfer - invalid filename */
@@ -319,5 +322,408 @@ void guac_sftp_set_upload_path(guac_client* client, char* path) {
     memcpy(client_data->sftp_upload_path, path, length);
     guac_client_log(client, GUAC_LOG_DEBUG, "Upload path set to \"%s\"", path);
 
+}
+
+guac_object* guac_sftp_expose_filesystem(guac_client* client) {
+
+    /* Init filesystem */
+    guac_object* filesystem = guac_client_alloc_object(client);
+    filesystem->get_handler = guac_sftp_get_handler;
+    filesystem->put_handler = guac_sftp_put_handler;
+
+    /* Send filesystem to client */
+    guac_protocol_send_filesystem(client->socket, filesystem, "/");
+    guac_socket_flush(client->socket);
+
+    /* Return allocated filesystem */
+    return filesystem;
+
+}
+
+/**
+ * Given a stream, the client to which it belongs, and the current directory
+ * list state, flushes the contents of the JSON buffer to a blob instruction.
+ * Note that this will flush the JSON buffer only, and will not necessarily
+ * flush the underlying guac_socket of the client.
+ *
+ * @param client
+ *     The client to which the data will be flushed.
+ *
+ * @param stream
+ *     The stream through which the flushed data should be sent as a blob.
+ *
+ * @param list_state
+ *     The directory list state.
+ */
+static void guac_sftp_ls_flush_json(guac_client* client, guac_stream* stream,
+        guac_sftp_ls_state* list_state) {
+
+    /* If JSON buffer is non-empty, write contents to blob and reset */
+    if (list_state->json_size > 0) {
+        guac_protocol_send_blob(client->socket, stream,
+                list_state->json_buffer, list_state->json_size);
+
+        /* Reset JSON buffer size */
+        list_state->json_size = 0;
+
+    }
+
+}
+
+/**
+ * Given a stream, the client to which it belongs, and the current directory
+ * list state, writes the contents of the given buffer to the JSON buffer of
+ * the directory list state, flushing as necessary.
+ *
+ * @param client
+ *     The client to which the data will be flushed as necessary.
+ *
+ * @param stream
+ *     The stream through which the flushed data should be sent as a blob, if
+ *     data must be flushed at all.
+ *
+ * @param list_state
+ *     The directory list state containing the JSON buffer to which the given
+ *     buffer should be written.
+ *
+ * @param buffer
+ *     The buffer to write.
+ *
+ * @param length
+ *     The number of bytes in the buffer.
+ *
+ * @return
+ *     true if at least one blob was written, false otherwise.
+ */
+static bool guac_sftp_ls_write_json(guac_client* client, guac_stream* stream,
+        guac_sftp_ls_state* list_state, const char* buffer, int length) {
+
+    bool blob_written = false;
+
+    /*
+     * Append to and flush the JSON buffer as necessary to write the given
+     * data
+     */
+    while (length > 0) {
+
+        /* Ensure provided data does not exceed size of buffer */
+        int blob_length = length;
+        if (blob_length > sizeof(list_state->json_buffer))
+            blob_length = sizeof(list_state->json_buffer);
+
+        /* Flush if more room is needed */
+        if (list_state->json_size + blob_length > sizeof(list_state->json_buffer)) {
+            guac_sftp_ls_flush_json(client, stream, list_state);
+            blob_written = true;
+        }
+
+        /* Append data to JSON buffer */
+        memcpy(list_state->json_buffer + list_state->json_size,
+                buffer, blob_length);
+
+        list_state->json_size += blob_length;
+
+        /* Advance to next blob of data */
+        buffer += blob_length;
+        length -= blob_length;
+
+    }
+
+    return blob_written;
+
+}
+
+/**
+ * Given a stream, the client to which it belongs, and the current directory
+ * list state, writes the given string as a proper JSON string, including
+ * starting and ending quotes. The contents of the string will be escaped as
+ * necessary.
+ *
+ * @param client
+ *     The client to which the data will be flushed as necessary.
+ *
+ * @param stream
+ *     The stream through which the flushed data should be sent as a blob, if
+ *     data must be flushed at all.
+ *
+ * @param list_state
+ *     The directory list state containing the JSON buffer to which the given
+ *     string should be written as a proper JSON string.
+ *
+ * @param str
+ *     The string to write.
+ *
+ * @return
+ *     true if at least one blob was written, false otherwise.
+ */
+static bool guac_sftp_ls_write_json_string(guac_client* client,
+        guac_stream* stream, guac_sftp_ls_state* list_state,
+        const char* str) {
+
+    bool blob_written = false;
+
+    /* Write starting quote */
+    blob_written |= guac_sftp_ls_write_json(client, stream,
+            list_state, "\"", 1);
+
+    /* Write given string, escaping as necessary */
+    const char* current = str;
+    for (; *current != '\0'; current++) {
+
+        /* Escape all quotes */
+        if (*current == '"') {
+
+            /* Write any string content up to current character */
+            if (current != str)
+                blob_written |= guac_sftp_ls_write_json(client, stream,
+                        list_state, str, current - str);
+
+            /* Escape the quote that was just read */
+            blob_written |= guac_sftp_ls_write_json(client, stream,
+                    list_state, "\\", 1);
+
+            /* Reset string */
+            str = current;
+
+        }
+
+    }
+
+    /* Write any remaining string content */
+    if (current != str)
+        blob_written |= guac_sftp_ls_write_json(client, stream,
+                list_state, str, current - str);
+
+    /* Write ending quote */
+    blob_written |= guac_sftp_ls_write_json(client, stream,
+            list_state, "\"", 1);
+
+    return blob_written;
+
+}
+
+/**
+ * Given a stream, the client to which it belongs, and the current directory
+ * list state, writes the given directory entry as a JSON name/value pair. The
+ * name and value will be written as proper JSON strings separated by a colon.
+ *
+ * @param client
+ *     The client to which the data will be flushed as necessary.
+ *
+ * @param stream
+ *     The stream through which the flushed data should be sent as a blob, if
+ *     data must be flushed at all.
+ *
+ * @param list_state
+ *     The directory list state containing the JSON buffer to which the given
+ *     directory should be written as a JSON name/value pair.
+ *
+ * @param mimetype
+ *     The mimetype of the directory entry to write.
+ *
+ * @param filename
+ *     The filename of the directory entry to write.
+ *
+ * @return
+ *     true if at least one blob was written, false otherwise.
+ */
+static bool guac_sftp_ls_write_entry(guac_client* client, guac_stream* stream,
+        guac_sftp_ls_state* list_state, const char* mimetype,
+        const char* filename) {
+
+    bool blob_written = false;
+
+    /* Write leading comma if not first entry */
+    if (list_state->entries_written != 0)
+        blob_written |= guac_sftp_ls_write_json(client, stream,
+                list_state, ",", 1);
+
+    /* Write filename */
+    blob_written |= guac_sftp_ls_write_json_string(client, stream,
+            list_state, filename);
+
+    /* Separate filename from mimetype with colon */
+    blob_written |= guac_sftp_ls_write_json(client, stream,
+            list_state, ":", 1);
+
+    /* Write mimetype */
+    blob_written |= guac_sftp_ls_write_json_string(client, stream,
+            list_state, mimetype);
+
+    list_state->entries_written++;
+
+    return blob_written;
+
+}
+
+int guac_sftp_ls_ack_handler(guac_client* client, guac_stream* stream,
+        char* message, guac_protocol_status status) {
+
+    int bytes_read;
+    bool blob_written = false;
+
+    char filename[GUAC_SFTP_MAX_PATH];
+    LIBSSH2_SFTP_ATTRIBUTES attributes;
+
+    ssh_guac_client_data* client_data = (ssh_guac_client_data*) client->data;
+    LIBSSH2_SFTP* sftp = client_data->sftp_session;
+    guac_sftp_ls_state* list_state = (guac_sftp_ls_state*) stream->data;
+
+    /* If unsuccessful, free stream and abort */
+    if (status != GUAC_PROTOCOL_STATUS_SUCCESS) {
+        libssh2_sftp_closedir(list_state->directory);
+        guac_client_free_stream(client, stream);
+        free(list_state);
+        return 0;
+    }
+
+    /* While directory entries remain */
+    while ((bytes_read = libssh2_sftp_readdir(list_state->directory,
+                filename, sizeof(filename), &attributes)) > 0
+            && !blob_written) {
+
+        char absolute_path[GUAC_SFTP_MAX_PATH];
+
+        /* Skip current and parent directory entries */
+        if (strcmp(filename, ".") == 0 || strcmp(filename, "..") == 0)
+            continue;
+
+        /* Concatenate into absolute path - skip if invalid */
+        if (!guac_ssh_append_filename(absolute_path, 
+                    list_state->directory_name, filename)) {
+
+            guac_client_log(client, GUAC_LOG_DEBUG,
+                    "Skipping filename \"%s\" - filename is invalid or "
+                    "resulting path is too long", filename);
+
+            continue;
+        }
+
+        /* Stat explicitly if symbolic link (might point to directory) */
+        if (LIBSSH2_SFTP_S_ISLNK(attributes.permissions))
+            libssh2_sftp_stat(sftp, absolute_path, &attributes);
+
+        /* Determine mimetype */
+        const char* mimetype;
+        if (LIBSSH2_SFTP_S_ISDIR(attributes.permissions))
+            mimetype = GUAC_CLIENT_STREAM_INDEX_MIMETYPE;
+        else
+            mimetype = "application/octet-stream";
+
+        /* Write leading brace if just starting */
+        if (list_state->entries_written == 0)
+            blob_written |= guac_sftp_ls_write_json(client, stream,
+                    list_state, "{", 1);
+
+        /* Write entry */
+        blob_written |= guac_sftp_ls_write_entry(client, stream,
+                list_state, mimetype, absolute_path);
+
+    }
+
+    /* Complete JSON and cleanup at end of directory */
+    if (bytes_read <= 0) {
+
+        /* Write end of JSON */
+        guac_sftp_ls_write_json(client, stream, list_state, "}", 1);
+        guac_sftp_ls_flush_json(client, stream, list_state);
+
+        /* Clean up resources */
+        libssh2_sftp_closedir(list_state->directory);
+        free(list_state);
+
+        /* Signal of stream */
+        guac_protocol_send_end(client->socket, stream);
+        guac_client_free_stream(client, stream);
+
+    }
+
+    guac_socket_flush(client->socket);
+    return 0;
+
+}
+
+int guac_sftp_get_handler(guac_client* client, guac_object* object,
+        char* name) {
+
+    ssh_guac_client_data* client_data = (ssh_guac_client_data*) client->data;
+    LIBSSH2_SFTP* sftp = client_data->sftp_session;
+    LIBSSH2_SFTP_ATTRIBUTES attributes;
+
+    /* Attempt to read file information */
+    if (libssh2_sftp_stat(sftp, name, &attributes)) {
+        guac_client_log(client, GUAC_LOG_INFO, "Unable to read file \"%s\"",
+                name);
+        return 0;
+    }
+
+    /* If directory, send contents of directory */
+    if (LIBSSH2_SFTP_S_ISDIR(attributes.permissions)) {
+
+        /* Open as directory */
+        LIBSSH2_SFTP_HANDLE* dir = libssh2_sftp_opendir(sftp, name);
+        if (dir == NULL) {
+            guac_client_log(client, GUAC_LOG_INFO,
+                    "Unable to read directory \"%s\": %s",
+                    name, libssh2_sftp_last_error(sftp));
+            return 0;
+        }
+
+        /* Init directory listing state */
+        guac_sftp_ls_state* list_state = malloc(sizeof(guac_sftp_ls_state));
+
+        list_state->directory = dir;
+        strncpy(list_state->directory_name, name,
+                sizeof(list_state->directory_name));
+
+        list_state->json_size = 0;
+        list_state->entries_written = 0;
+
+        /* Allocate stream for body */
+        guac_stream* stream = guac_client_alloc_stream(client);
+        stream->ack_handler = guac_sftp_ls_ack_handler;
+        stream->data = list_state;
+
+        /* Associate new stream with get request */
+        guac_protocol_send_body(client->socket, object, stream,
+                GUAC_CLIENT_STREAM_INDEX_MIMETYPE, name);
+
+    }
+
+    /* Otherwise, send file contents */
+    else {
+
+        /* Open as normal file */
+        LIBSSH2_SFTP_HANDLE* file = libssh2_sftp_open(sftp, name,
+            LIBSSH2_FXF_READ, 0);
+        if (file == NULL) {
+            guac_client_log(client, GUAC_LOG_INFO,
+                    "Unable to read file \"%s\": %s",
+                    name, libssh2_sftp_last_error(sftp));
+            return 0;
+        }
+
+        /* Allocate stream for body */
+        guac_stream* stream = guac_client_alloc_stream(client);
+        stream->ack_handler = guac_sftp_ack_handler;
+        stream->data = file;
+
+        /* Associate new stream with get request */
+        guac_protocol_send_body(client->socket, object, stream,
+                "application/octet-stream", name);
+
+    }
+
+    guac_socket_flush(client->socket);
+    return 0;
+}
+
+int guac_sftp_put_handler(guac_client* client, guac_object* object,
+        guac_stream* stream, char* mimetype, char* name) {
+
+    /* STUB */
+    guac_client_log(client, GUAC_LOG_DEBUG, "STUB: put: %s", name);
+
+    return 0;
 }
 

--- a/src/protocols/ssh/sftp.c
+++ b/src/protocols/ssh/sftp.c
@@ -52,7 +52,7 @@
  *     The path to append the filename to.
  *
  * @param filename
- *     The filename to appaned to the path.
+ *     The filename to append to the path.
  *
  * @return
  *     true if the filename is valid and was successfully appended to the path,

--- a/src/protocols/ssh/sftp.h
+++ b/src/protocols/ssh/sftp.h
@@ -108,7 +108,9 @@ guac_stream* guac_sftp_download_file(guac_client* client, char* filename);
 void guac_sftp_set_upload_path(guac_client* client, char* path);
 
 /**
- * Exposes access to SFTP via a filesystem object, returning that object.
+ * Exposes access to SFTP via a filesystem object, returning that object. The
+ * object returned must eventually be explicitly freed through a call to
+ * guac_client_free_object().
  *
  * @param client
  *     The Guacamole client to expose the filesystem to.

--- a/src/protocols/ssh/sftp.h
+++ b/src/protocols/ssh/sftp.h
@@ -26,7 +26,11 @@
 
 #include "config.h"
 
+#include <libssh2.h>
+#include <libssh2_sftp.h>
+
 #include <guacamole/client.h>
+#include <guacamole/object.h>
 #include <guacamole/protocol.h>
 #include <guacamole/stream.h>
 
@@ -34,6 +38,41 @@
  * Maximum number of bytes per path.
  */
 #define GUAC_SFTP_MAX_PATH 2048
+
+/**
+ * The current state of a directory listing operation.
+ */
+typedef struct guac_sftp_ls_state {
+
+    /**
+     * Reference to the directory currently being listed over SFTP. This
+     * directory must already be open from a call to libssh2_sftp_opendir().
+     */
+    LIBSSH2_SFTP_HANDLE* directory;
+
+    /**
+     * The absolute path of the directory being listed.
+     */
+    char directory_name[GUAC_SFTP_MAX_PATH];
+
+    /**
+     * Buffer of partial JSON data. The individual blobs which make up the JSON
+     * body of the directory listing sent over the Guacamole protocol will be
+     * built here.
+     */
+    char json_buffer[4096];
+
+    /**
+     * The number of bytes currently used within the JSON buffer.
+     */
+    int json_size;
+
+    /**
+     * The number of entries written to the JSON thus far.
+     */
+    int entries_written;
+
+} guac_sftp_ls_state;
 
 /**
  * Handler for file messages which begins an SFTP data transfer (upload).
@@ -67,6 +106,89 @@ guac_stream* guac_sftp_download_file(guac_client* client, char* filename);
  * Set the destination directory for future uploads.
  */
 void guac_sftp_set_upload_path(guac_client* client, char* path);
+
+/**
+ * Exposes access to SFTP via a filesystem object, returning that object.
+ *
+ * @param client
+ *     The Guacamole client to expose the filesystem to.
+ *
+ * @return
+ *     The resulting Guacamole filesystem object, initialized and exposed to
+ *     the client.
+ */
+guac_object* guac_sftp_expose_filesystem(guac_client* client);
+
+/**
+ * Handler for get messages. In context of SFTP and the filesystem exposed via
+ * the Guacamole protocol, get messages request the body of a file within the
+ * filesystem.
+ *
+ * @param client
+ *     The client receiving the get message.
+ *
+ * @param object
+ *     The Guacamole protocol object associated with the get request itself.
+ *
+ * @param name
+ *     The name of the input stream (file) being requested.
+ *
+ * @return
+ *     Zero on success, non-zero on error.
+ */
+int guac_sftp_get_handler(guac_client* client, guac_object* object,
+        char* name);
+
+/**
+ * Handler for put messages. In context of SFTP and the filesystem exposed via
+ * the Guacamole protocol, put messages request write access to a file within
+ * the filesystem.
+ *
+ * @param client
+ *     The client receiving the put message.
+ *
+ * @param object
+ *     The Guacamole protocol object associated with the put request itself.
+ *
+ * @param stream
+ *     The Guacamole protocol stream along which the client will be sending
+ *     file data.
+ *
+ * @param mimetype
+ *     The mimetype of the data being send along the stream.
+ *
+ * @param name
+ *     The name of the input stream (file) being requested.
+ *
+ * @return
+ *     Zero on success, non-zero on error.
+ */
+int guac_sftp_put_handler(guac_client* client, guac_object* object,
+        guac_stream* stream, char* mimetype, char* name);
+
+/**
+ * Handler for ack messages received due to receipt of a "body" or "blob"
+ * instruction associated with a SFTP directory list operation.
+ *
+ * @param client
+ *     The client receiving the ack message.
+ *
+ * @param stream
+ *     The Guacamole protocol stream associated with the received ack message.
+ *
+ * @param message
+ *     An arbitrary human-readable message describing the nature of the
+ *     success or failure denoted by this ack message.
+ *
+ * @param status
+ *     The status code associated with this ack message, which may indicate
+ *     success or an error.
+ *
+ * @return
+ *     Zero on success, non-zero on error.
+ */
+int guac_sftp_ls_ack_handler(guac_client* client, guac_stream* stream,
+        char* message, guac_protocol_status status);
 
 #endif
 

--- a/src/protocols/ssh/ssh_client.c
+++ b/src/protocols/ssh/ssh_client.c
@@ -476,6 +476,9 @@ void* ssh_client_thread(void* data) {
         /* Set file handler */
         client->file_handler = guac_sftp_file_handler;
 
+        /* Expose filesystem */
+        guac_sftp_expose_filesystem(client);
+
         guac_client_log(client, GUAC_LOG_DEBUG, "SFTP session initialized");
 
     }

--- a/src/protocols/ssh/ssh_client.c
+++ b/src/protocols/ssh/ssh_client.c
@@ -477,7 +477,7 @@ void* ssh_client_thread(void* data) {
         client->file_handler = guac_sftp_file_handler;
 
         /* Expose filesystem */
-        guac_sftp_expose_filesystem(client);
+        client_data->sftp_filesystem = guac_sftp_expose_filesystem(client);
 
         guac_client_log(client, GUAC_LOG_DEBUG, "SFTP session initialized");
 


### PR DESCRIPTION
This change exposes SFTP functionality through Guacamole's new filesystem object, allowing direct listing of directories and upload/download of files (without requiring the use of `guacctl`).

The old mechanism using `guacctl` is unaffected, and continues to be supported.