### PR TITLE
GUAC-1172: Implement filesystem object support for RDP.

### DIFF
--- a/src/common/guac_json.c
+++ b/src/common/guac_json.c
@@ -48,10 +48,10 @@ void guac_common_json_flush(guac_client* client, guac_stream* stream,
 
 }
 
-bool guac_common_json_write(guac_client* client, guac_stream* stream,
+int guac_common_json_write(guac_client* client, guac_stream* stream,
         guac_common_json_state* json_state, const char* buffer, int length) {
 
-    bool blob_written = false;
+    int blob_written = 0;
 
     /*
      * Append to and flush the JSON buffer as necessary to write the given
@@ -67,7 +67,7 @@ bool guac_common_json_write(guac_client* client, guac_stream* stream,
         /* Flush if more room is needed */
         if (json_state->size + blob_length > sizeof(json_state->buffer)) {
             guac_common_json_flush(client, stream, json_state);
-            blob_written = true;
+            blob_written = 1;
         }
 
         /* Append data to JSON buffer */
@@ -86,11 +86,11 @@ bool guac_common_json_write(guac_client* client, guac_stream* stream,
 
 }
 
-bool guac_common_json_write_string(guac_client* client,
+int guac_common_json_write_string(guac_client* client,
         guac_stream* stream, guac_common_json_state* json_state,
         const char* str) {
 
-    bool blob_written = false;
+    int blob_written = 0;
 
     /* Write starting quote */
     blob_written |= guac_common_json_write(client, stream,
@@ -132,11 +132,11 @@ bool guac_common_json_write_string(guac_client* client,
 
 }
 
-bool guac_common_json_write_property(guac_client* client, guac_stream* stream,
+int guac_common_json_write_property(guac_client* client, guac_stream* stream,
         guac_common_json_state* json_state, const char* name,
         const char* value) {
 
-    bool blob_written = false;
+    int blob_written = 0;
 
     /* Write leading comma if not first property */
     if (json_state->properties_written != 0)
@@ -173,7 +173,7 @@ void guac_common_json_begin_object(guac_client* client, guac_stream* stream,
 
 }
 
-bool guac_common_json_end_object(guac_client* client, guac_stream* stream,
+int guac_common_json_end_object(guac_client* client, guac_stream* stream,
         guac_common_json_state* json_state) {
 
     /* Write final brace of JSON object */

--- a/src/common/guac_json.h
+++ b/src/common/guac_json.h
@@ -25,8 +25,6 @@
 
 #include "config.h"
 
-#include <stdbool.h>
-
 #include <guacamole/client.h>
 #include <guacamole/stream.h>
 
@@ -97,9 +95,9 @@ void guac_common_json_flush(guac_client* client, guac_stream* stream,
  *     The number of bytes in the buffer.
  *
  * @return
- *     true if at least one blob was written, false otherwise.
+ *     Non-zero if at least one blob was written, zero otherwise.
  */
-bool guac_common_json_write(guac_client* client, guac_stream* stream,
+int guac_common_json_write(guac_client* client, guac_stream* stream,
         guac_common_json_state* json_state, const char* buffer, int length);
 
 /**
@@ -123,9 +121,9 @@ bool guac_common_json_write(guac_client* client, guac_stream* stream,
  *     The string to write.
  *
  * @return
- *     true if at least one blob was written, false otherwise.
+ *     Non-zero if at least one blob was written, zero otherwise.
  */
-bool guac_common_json_write_string(guac_client* client,
+int guac_common_json_write_string(guac_client* client,
         guac_stream* stream, guac_common_json_state* json_state,
         const char* str);
 
@@ -152,9 +150,9 @@ bool guac_common_json_write_string(guac_client* client,
  *     The value of the property to write.
  *
  * @return
- *     true if at least one blob was written, false otherwise.
+ *     Non-zero if at least one blob was written, zero otherwise.
  */
-bool guac_common_json_write_property(guac_client* client, guac_stream* stream,
+int guac_common_json_write_property(guac_client* client, guac_stream* stream,
         guac_common_json_state* json_state, const char* name,
         const char* value);
 
@@ -192,9 +190,9 @@ void guac_common_json_begin_object(guac_client* client, guac_stream* stream,
  *     The state object whose in-progress JSON object should be terminated.
  *
  * @return
- *     true if at least one blob was written, false otherwise.
+ *     Non-zero if at least one blob was written, zero otherwise.
  */
-bool guac_common_json_end_object(guac_client* client, guac_stream* stream,
+int guac_common_json_end_object(guac_client* client, guac_stream* stream,
         guac_common_json_state* json_state);
 
 #endif

--- a/src/protocols/rdp/guac_rdpdr/rdpdr_fs_service.c
+++ b/src/protocols/rdp/guac_rdpdr/rdpdr_fs_service.c
@@ -30,6 +30,8 @@
 
 #include <freerdp/utils/svc_plugin.h>
 #include <guacamole/client.h>
+#include <guacamole/protocol.h>
+#include <guacamole/socket.h>
 
 #ifdef ENABLE_WINPR
 #include <winpr/stream.h>
@@ -151,6 +153,11 @@ void guac_rdpdr_register_fs(guac_rdpdrPlugin* rdpdr) {
 
     /* Init data */
     device->data = data->filesystem;
+
+    /* Announce filesystem to client */
+    guac_protocol_send_filesystem(rdpdr->client->socket,
+            data->filesystem->object, "Shared Drive");
+    guac_socket_flush(rdpdr->client->socket);
 
 }
 

--- a/src/protocols/rdp/rdp_fs.c
+++ b/src/protocols/rdp/rdp_fs.c
@@ -24,6 +24,7 @@
 
 #include "rdp_fs.h"
 #include "rdp_status.h"
+#include "rdp_stream.h"
 
 #include <dirent.h>
 #include <errno.h>
@@ -45,6 +46,8 @@ guac_rdp_fs* guac_rdp_fs_alloc(guac_client* client, const char* drive_path) {
 
     fs->client = client;
     fs->object = guac_client_alloc_object(client);
+    fs->object->get_handler = guac_rdp_download_get_handler;
+    fs->object->put_handler = guac_rdp_upload_put_handler;
 
     fs->drive_path = strdup(drive_path);
     fs->file_id_pool = guac_pool_alloc(0);
@@ -180,7 +183,7 @@ int guac_rdp_fs_open(guac_rdp_fs* fs, const char* path,
         path = "\\";
 
     /* If path is relative, the file does not exist */
-    else if (path[0] != '\\') {
+    else if (path[0] != '\\' && path[0] != '/') {
         guac_client_log(fs->client, GUAC_LOG_DEBUG,
                 "%s: Access denied - supplied path \"%s\" is relative.",
                 __func__, path);
@@ -689,6 +692,68 @@ int guac_rdp_fs_get_info(guac_rdp_fs* fs, guac_rdp_fs_info* info) {
     info->blocks_total = fs_stat.f_blocks;
     info->block_size = fs_stat.f_bsize;
     return 0;
+
+}
+
+int guac_rdp_fs_append_filename(char* fullpath, const char* path,
+        const char* filename) {
+
+    int i;
+
+    /* Disallow "." as a filename */
+    if (strcmp(filename, ".") == 0)
+        return 0;
+
+    /* Disallow ".." as a filename */
+    if (strcmp(filename, "..") == 0)
+        return 0;
+
+    /* Copy path, append trailing slash */
+    for (i=0; i<GUAC_RDP_FS_MAX_PATH; i++) {
+
+        /*
+         * Append trailing slash only if:
+         *  1) Trailing slash is not already present
+         *  2) Path is non-empty
+         */
+
+        char c = path[i];
+        if (c == '\0') {
+            if (i > 0 && path[i-1] != '/' && path[i-1] != '\\')
+                fullpath[i++] = '/';
+            break;
+        }
+
+        /* Copy character if not end of string */
+        fullpath[i] = c;
+
+    }
+
+    /* Append filename */
+    for (; i<GUAC_RDP_FS_MAX_PATH; i++) {
+
+        char c = *(filename++);
+        if (c == '\0')
+            break;
+
+        /* Filenames may not contain slashes */
+        if (c == '\\' || c == '/')
+            return 0;
+
+        /* Append each character within filename */
+        fullpath[i] = c;
+
+    }
+
+    /* Verify path length is within maximum */
+    if (i == GUAC_RDP_FS_MAX_PATH)
+        return 0;
+
+    /* Terminate path string */
+    fullpath[i] = '\0';
+
+    /* Append was successful */
+    return 1;
 
 }
 

--- a/src/protocols/rdp/rdp_fs.c
+++ b/src/protocols/rdp/rdp_fs.c
@@ -36,6 +36,7 @@
 #include <sys/statvfs.h>
 #include <unistd.h>
 
+#include <guacamole/object.h>
 #include <guacamole/pool.h>
 
 guac_rdp_fs* guac_rdp_fs_alloc(guac_client* client, const char* drive_path) {
@@ -43,6 +44,8 @@ guac_rdp_fs* guac_rdp_fs_alloc(guac_client* client, const char* drive_path) {
     guac_rdp_fs* fs = malloc(sizeof(guac_rdp_fs));
 
     fs->client = client;
+    fs->object = guac_client_alloc_object(client);
+
     fs->drive_path = strdup(drive_path);
     fs->file_id_pool = guac_pool_alloc(0);
     fs->open_files = 0;
@@ -52,6 +55,7 @@ guac_rdp_fs* guac_rdp_fs_alloc(guac_client* client, const char* drive_path) {
 }
 
 void guac_rdp_fs_free(guac_rdp_fs* fs) {
+    guac_client_free_object(fs->client, fs->object);
     guac_pool_free(fs->file_id_pool);
     free(fs->drive_path);
     free(fs);

--- a/src/protocols/rdp/rdp_fs.h
+++ b/src/protocols/rdp/rdp_fs.h
@@ -428,5 +428,27 @@ int guac_rdp_fs_matches(const char* filename, const char* pattern);
  */
 int guac_rdp_fs_get_info(guac_rdp_fs* fs, guac_rdp_fs_info* info);
 
+/**
+ * Concatenates the given filename with the given path, separating the two
+ * with a single forward slash. The full result must be no more than
+ * GUAC_RDP_FS_MAX_PATH bytes long, counting null terminator.
+ *
+ * @param fullpath
+ *     The buffer to store the result within. This buffer must be at least
+ *     GUAC_RDP_FS_MAX_PATH bytes long.
+ *
+ * @param path
+ *     The path to append the filename to.
+ *
+ * @param filename
+ *     The filename to append to the path.
+ *
+ * @return
+ *     Non-zero if the filename is valid and was successfully appended to the
+ *     path, zero otherwise.
+ */
+int guac_rdp_fs_append_filename(char* fullpath, const char* path,
+        const char* filename);
+
 #endif
 

--- a/src/protocols/rdp/rdp_fs.h
+++ b/src/protocols/rdp/rdp_fs.h
@@ -38,6 +38,7 @@
 #include "config.h"
 
 #include <guacamole/client.h>
+#include <guacamole/object.h>
 #include <guacamole/pool.h>
 
 #include <dirent.h>
@@ -271,6 +272,11 @@ typedef struct guac_rdp_fs {
      * The controlling client.
      */
     guac_client* client;
+
+    /**
+     * The underlying filesystem object.
+     */
+    guac_object* object;
 
     /**
      * The root of the filesystem.

--- a/src/protocols/rdp/rdp_status.h
+++ b/src/protocols/rdp/rdp_status.h
@@ -32,6 +32,14 @@
 
 #include "config.h"
 
+/* Include any constants from winpr/file.h, if available */
+
+#ifdef ENABLE_WINPR
+#include <winpr/file.h>
+#endif
+
+/* Constants which MAY be defined within FreeRDP */
+
 #ifndef STATUS_SUCCESS
 #define STATUS_SUCCESS                  0x00000000
 #define STATUS_NO_MORE_FILES            0x80000006
@@ -52,6 +60,8 @@
 #define STATUS_FILE_DELETED             0xC0000123
 #define STATUS_FILE_CLOSED              0xC0000128
 #endif
+
+/* Constants which are NEVER defined within FreeRDP */
 
 #define STATUS_FILE_SYSTEM_LIMITATION   0xC0000427
 #define STATUS_FILE_TOO_LARGE           0xC0000904


### PR DESCRIPTION
This change adds support for Guacamole's new filesystem objects (and thus file browsing) to the existing RDP file transfer support. The changes are modeled after the changes made to SSH to support the same, but follow the established `guac_rdp_stream` pattern from past RDP changes.

FreeRDP does some things which clash with use of the standard `bool` type provided by `stdbool.h`, so I've also had to remove use of `bool` from the new `guac_json` functions added to common.