### PR TITLE
GUAC-1264: Fix segfault in password handling

### DIFF
--- a/src/common-ssh/guac_sftp.c
+++ b/src/common-ssh/guac_sftp.c
@@ -707,8 +707,5 @@ void guac_common_ssh_destroy_sftp_filesystem(guac_object* filesystem) {
     /* Clean up the SFTP filesystem object */
     guac_client_free_object(sftp_data->ssh_session->client, filesystem);
 
-    /* Disconnect SSH session corresponding to the SFTP session */
-    guac_common_ssh_destroy_session(sftp_data->ssh_session);
-
 }
 

--- a/src/common-ssh/guac_sftp.h
+++ b/src/common-ssh/guac_sftp.h
@@ -110,7 +110,8 @@ guac_object* guac_common_ssh_create_sftp_filesystem(
 
 /**
  * Destroys the given filesystem object, disconnecting from SFTP and freeing
- * and associated resources.
+ * and associated resources. Any associated session or user objects must be
+ * explicitly destroyed.
  *
  * @param object
  *     The filesystem object to destroy.

--- a/src/common-ssh/guac_ssh.c
+++ b/src/common-ssh/guac_ssh.c
@@ -504,10 +504,6 @@ void guac_common_ssh_destroy_session(guac_common_ssh_session* session) {
     libssh2_session_disconnect(session->session, "Bye");
     libssh2_session_free(session->session);
 
-    /* Destroy associated user */
-    if (session->user)
-        guac_common_ssh_destroy_user(session->user);
-
     /* Free all other data */
     free(session);
 

--- a/src/common-ssh/guac_ssh.h
+++ b/src/common-ssh/guac_ssh.h
@@ -80,6 +80,9 @@ void guac_common_ssh_uninit();
  * Connects to the SSH server running at the given hostname and port, and
  * authenticates as the given user. If an error occurs while connecting or
  * authenticating, the Guacamole client will automatically and fatally abort.
+ * The user object provided must eventually be explicitly destroyed, but should
+ * not be destroyed until this session is destroyed, assuming the session is
+ * successfully created.
  *
  * @param client
  *     The Guacamole client that will be using SSH.
@@ -91,8 +94,7 @@ void guac_common_ssh_uninit();
  *     The port to connect to on the given hostname.
  *
  * @param user
- *     The user to authenticate as, once connected. This user will be
- *     automatically destroyed when this session is destroyed.
+ *     The user to authenticate as, once connected.
  *
  * @return
  *     A new SSH session if the connection and authentication succeed, or NULL
@@ -103,7 +105,8 @@ guac_common_ssh_session* guac_common_ssh_create_session(guac_client* client,
 
 /**
  * Disconnects and destroys the given SSH session, freeing all associated
- * resources.
+ * resources. Any associated user must be explicitly destroyed, and will not
+ * be destroyed automatically.
  *
  * @param session
  *     The SSH session to destroy.

--- a/src/protocols/rdp/client.c
+++ b/src/protocols/rdp/client.c
@@ -857,7 +857,7 @@ int guac_client_init(guac_client* client, int argc, char** argv) {
                     "Authenticating with password.");
 
             /* Parse password - use RDP password by default */
-            const char* sftp_password = argv[IDX_SFTP_USERNAME];
+            const char* sftp_password = argv[IDX_SFTP_PASSWORD];
             if (sftp_password[0] == '\0' && settings->password != NULL)
                 sftp_password = settings->password;
 

--- a/src/protocols/rdp/client.c
+++ b/src/protocols/rdp/client.c
@@ -831,7 +831,8 @@ int guac_client_init(guac_client* client, int argc, char** argv) {
         if (sftp_username[0] == '\0' && settings->username != NULL)
             sftp_username = settings->username;
 
-        guac_common_ssh_user* user = guac_common_ssh_create_user(sftp_username);
+        guac_client_data->sftp_user =
+            guac_common_ssh_create_user(sftp_username);
 
         /* Import private key, if given */
         if (argv[IDX_SFTP_PRIVATE_KEY][0] != '\0') {
@@ -840,10 +841,10 @@ int guac_client_init(guac_client* client, int argc, char** argv) {
                     "Authenticating with private key.");
 
             /* Abort if private key cannot be read */
-            if (guac_common_ssh_user_import_key(user,
+            if (guac_common_ssh_user_import_key(guac_client_data->sftp_user,
                         argv[IDX_SFTP_PRIVATE_KEY],
                         argv[IDX_SFTP_PASSPHRASE])) {
-                guac_common_ssh_destroy_user(user);
+                guac_common_ssh_destroy_user(guac_client_data->sftp_user);
                 return 1;
             }
 
@@ -860,7 +861,8 @@ int guac_client_init(guac_client* client, int argc, char** argv) {
             if (sftp_password[0] == '\0' && settings->password != NULL)
                 sftp_password = settings->password;
 
-            guac_common_ssh_user_set_password(user, sftp_password);
+            guac_common_ssh_user_set_password(guac_client_data->sftp_user,
+                    sftp_password);
 
         }
 
@@ -875,24 +877,28 @@ int guac_client_init(guac_client* client, int argc, char** argv) {
             sftp_port = "22";
 
         /* Attempt SSH connection */
-        guac_common_ssh_session* session =
+        guac_client_data->sftp_session =
             guac_common_ssh_create_session(client, sftp_hostname, sftp_port,
-                    user);
+                    guac_client_data->sftp_user);
 
         /* Fail if SSH connection does not succeed */
-        if (session == NULL) {
+        if (guac_client_data->sftp_session == NULL) {
             /* Already aborted within guac_common_ssh_create_session() */
-            guac_common_ssh_destroy_user(user);
+            guac_common_ssh_destroy_user(guac_client_data->sftp_user);
             return 1;
         }
 
         /* Load and expose filesystem */
         guac_client_data->sftp_filesystem =
-            guac_common_ssh_create_sftp_filesystem(session, "/");
+            guac_common_ssh_create_sftp_filesystem(
+                    guac_client_data->sftp_session, "/");
 
         /* Abort if SFTP connection fails */
-        if (guac_client_data->sftp_filesystem == NULL)
+        if (guac_client_data->sftp_filesystem == NULL) {
+            guac_common_ssh_destroy_session(guac_client_data->sftp_session);
+            guac_common_ssh_destroy_user(guac_client_data->sftp_user);
             return 1;
+        }
 
         /* Use SFTP for basic uploads, if drive not enabled */
         if (!settings->drive_enabled)

--- a/src/protocols/rdp/client.h
+++ b/src/protocols/rdp/client.h
@@ -35,6 +35,8 @@
 
 #ifdef ENABLE_COMMON_SSH
 #include "guac_sftp.h"
+#include "guac_ssh.h"
+#include "guac_ssh_user.h"
 #endif
 
 #ifdef HAVE_FREERDP_DISPLAY_UPDATE_SUPPORT
@@ -162,6 +164,16 @@ typedef struct rdp_guac_client_data {
     guac_rdp_fs* filesystem;
 
 #ifdef ENABLE_COMMON_SSH
+    /**
+     * The user and credentials used to authenticate for SFTP.
+     */
+    guac_common_ssh_user* sftp_user;
+
+    /**
+     * The SSH session used for SFTP.
+     */
+    guac_common_ssh_session* sftp_session;
+
     /**
      * The exposed filesystem object, implemented with SFTP.
      */

--- a/src/protocols/rdp/guac_handlers.c
+++ b/src/protocols/rdp/guac_handlers.c
@@ -36,6 +36,7 @@
 #ifdef ENABLE_COMMON_SSH
 #include <guac_sftp.h>
 #include <guac_ssh.h>
+#include <guac_ssh_user.h>
 #endif
 
 #include <freerdp/cache/cache.h>
@@ -98,6 +99,14 @@ int rdp_guac_client_free_handler(guac_client* client) {
     /* Free SFTP filesystem, if loaded */
     if (guac_client_data->sftp_filesystem)
         guac_common_ssh_destroy_sftp_filesystem(guac_client_data->sftp_filesystem);
+
+    /* Free SFTP session */
+    if (guac_client_data->sftp_session)
+        guac_common_ssh_destroy_session(guac_client_data->sftp_session);
+
+    /* Free SFTP user */
+    if (guac_client_data->sftp_user)
+        guac_common_ssh_destroy_user(guac_client_data->sftp_user);
 
     guac_common_ssh_uninit();
 #endif

--- a/src/protocols/ssh/client.c
+++ b/src/protocols/ssh/client.c
@@ -120,11 +120,10 @@ int guac_client_init(guac_client* client, int argc, char** argv) {
 
     guac_socket* socket = client->socket;
 
-    ssh_guac_client_data* client_data = malloc(sizeof(ssh_guac_client_data));
+    ssh_guac_client_data* client_data = calloc(1, sizeof(ssh_guac_client_data));
 
     /* Init client data */
     client->data = client_data;
-    client_data->term_channel = NULL;
 
     if (argc != SSH_ARGS_COUNT) {
         guac_client_abort(client, GUAC_PROTOCOL_STATUS_SERVER_ERROR, "Wrong number of arguments");
@@ -159,7 +158,6 @@ int guac_client_init(guac_client* client, int argc, char** argv) {
 
     /* Parse SFTP enable */
     client_data->enable_sftp = strcmp(argv[IDX_ENABLE_SFTP], "true") == 0;
-    client_data->sftp_filesystem = NULL;
 
 #ifdef ENABLE_SSH_AGENT
     client_data->enable_agent = strcmp(argv[IDX_ENABLE_AGENT], "true") == 0;

--- a/src/protocols/ssh/client.h
+++ b/src/protocols/ssh/client.h
@@ -27,6 +27,7 @@
 #include "config.h"
 
 #include "guac_ssh.h"
+#include "guac_ssh_user.h"
 #include "sftp.h"
 #include "terminal.h"
 
@@ -110,9 +111,19 @@ typedef struct ssh_guac_client_data {
     pthread_t client_thread;
 
     /**
+     * The user and credentials to use for all SSH sessions.
+     */
+    guac_common_ssh_user* user;
+
+    /**
      * SSH session, used by the SSH client thread.
      */
     guac_common_ssh_session* session;
+
+    /**
+     * SFTP session, used by the SFTP client/filesystem.
+     */
+    guac_common_ssh_session* sftp_session;
 
     /**
      * The filesystem object exposed for the SFTP session.

--- a/src/protocols/ssh/guac_handlers.c
+++ b/src/protocols/ssh/guac_handlers.c
@@ -102,13 +102,19 @@ int ssh_guac_client_free_handler(guac_client* client) {
     /* Free channels */
     libssh2_channel_free(guac_client_data->term_channel);
 
-    /* Clean up the SFTP filesystem object */
-    if (guac_client_data->sftp_filesystem)
+    /* Clean up the SFTP filesystem object and session */
+    if (guac_client_data->sftp_filesystem) {
         guac_common_ssh_destroy_sftp_filesystem(guac_client_data->sftp_filesystem);
+        guac_common_ssh_destroy_session(guac_client_data->sftp_session);
+    }
 
     /* Free session */
     if (guac_client_data->session != NULL)
         guac_common_ssh_destroy_session(guac_client_data->session);
+
+    /* Free user */
+    if (guac_client_data->user != NULL)
+        guac_common_ssh_destroy_user(guac_client_data->user);
 
     /* Free generic data struct */
     free(client->data);

--- a/src/protocols/vnc/client.c
+++ b/src/protocols/vnc/client.c
@@ -372,7 +372,7 @@ int guac_client_init(guac_client* client, int argc, char** argv) {
         guac_client_log(client, GUAC_LOG_DEBUG,
                 "Connecting via SSH for SFTP filesystem access.");
 
-        guac_common_ssh_user* user =
+        guac_client_data->sftp_user =
             guac_common_ssh_create_user(argv[IDX_SFTP_USERNAME]);
 
         /* Import private key, if given */
@@ -382,10 +382,10 @@ int guac_client_init(guac_client* client, int argc, char** argv) {
                     "Authenticating with private key.");
 
             /* Abort if private key cannot be read */
-            if (guac_common_ssh_user_import_key(user,
+            if (guac_common_ssh_user_import_key(guac_client_data->sftp_user,
                         argv[IDX_SFTP_PRIVATE_KEY],
                         argv[IDX_SFTP_PASSPHRASE])) {
-                guac_common_ssh_destroy_user(user);
+                guac_common_ssh_destroy_user(guac_client_data->sftp_user);
                 return 1;
             }
 
@@ -395,7 +395,8 @@ int guac_client_init(guac_client* client, int argc, char** argv) {
         else {
             guac_client_log(client, GUAC_LOG_DEBUG,
                     "Authenticating with password.");
-            guac_common_ssh_user_set_password(user, argv[IDX_SFTP_PASSWORD]);
+            guac_common_ssh_user_set_password(guac_client_data->sftp_user,
+                    argv[IDX_SFTP_PASSWORD]);
         }
 
         /* Parse hostname - use VNC hostname by default */
@@ -409,24 +410,28 @@ int guac_client_init(guac_client* client, int argc, char** argv) {
             sftp_port = "22";
 
         /* Attempt SSH connection */
-        guac_common_ssh_session* session =
+        guac_client_data->sftp_session =
             guac_common_ssh_create_session(client, sftp_hostname, sftp_port,
-                    user);
+                    guac_client_data->sftp_user);
 
         /* Fail if SSH connection does not succeed */
-        if (session == NULL) {
+        if (guac_client_data->sftp_session == NULL) {
             /* Already aborted within guac_common_ssh_create_session() */
-            guac_common_ssh_destroy_user(user);
+            guac_common_ssh_destroy_user(guac_client_data->sftp_user);
             return 1;
         }
 
         /* Load and expose filesystem */
         guac_client_data->sftp_filesystem =
-            guac_common_ssh_create_sftp_filesystem(session, "/");
+            guac_common_ssh_create_sftp_filesystem(
+                    guac_client_data->sftp_session, "/");
 
         /* Abort if SFTP connection fails */
-        if (guac_client_data->sftp_filesystem == NULL)
+        if (guac_client_data->sftp_filesystem == NULL) {
+            guac_common_ssh_destroy_session(guac_client_data->sftp_session);
+            guac_common_ssh_destroy_user(guac_client_data->sftp_user);
             return 1;
+        }
 
         /* Set file handler for basic uploads */
         client->file_handler = guac_vnc_sftp_file_handler;

--- a/src/protocols/vnc/client.h
+++ b/src/protocols/vnc/client.h
@@ -38,6 +38,8 @@
 
 #ifdef ENABLE_COMMON_SSH
 #include "guac_sftp.h"
+#include "guac_ssh.h"
+#include "guac_ssh_user.h"
 #endif
 
 /**
@@ -191,6 +193,16 @@ typedef struct vnc_guac_client_data {
     guac_common_surface* default_surface;
 
 #ifdef ENABLE_COMMON_SSH
+    /**
+     * The user and credentials used to authenticate for SFTP.
+     */
+    guac_common_ssh_user* sftp_user;
+
+    /**
+     * The SSH session used for SFTP.
+     */
+    guac_common_ssh_session* sftp_session;
+
     /**
      * The exposed filesystem object, implemented with SFTP.
      */

--- a/src/protocols/vnc/guac_handlers.c
+++ b/src/protocols/vnc/guac_handlers.c
@@ -34,6 +34,7 @@
 #ifdef ENABLE_COMMON_SSH
 #include <guac_sftp.h>
 #include <guac_ssh.h>
+#include <guac_ssh_user.h>
 #endif
 
 #ifdef ENABLE_PULSE
@@ -144,6 +145,14 @@ int vnc_guac_client_free_handler(guac_client* client) {
     /* Free SFTP filesystem, if loaded */
     if (guac_client_data->sftp_filesystem)
         guac_common_ssh_destroy_sftp_filesystem(guac_client_data->sftp_filesystem);
+
+    /* Free SFTP session */
+    if (guac_client_data->sftp_session)
+        guac_common_ssh_destroy_session(guac_client_data->sftp_session);
+
+    /* Free SFTP user */
+    if (guac_client_data->sftp_user)
+        guac_common_ssh_destroy_user(guac_client_data->sftp_user);
 
     guac_common_ssh_uninit();
 #endif


### PR DESCRIPTION
SFTP password passing for SSH and RDP was recently broken due to:

1. Broken logic within SSH parameter parsing (password auth would only be used if the password was **missing**).
2. Bad values within RDP (the "sftp-username" parameter was used for the password by mistake).

These issues lead to segfaults due to the lack of proper error handling in the newly-common SSH functions. If an auth attempt was made without any credentials whatsoever (as would universally happen due to the above breakage), the function would segfault rather than fail cleanly with a meaningful error. This PR should fix all that.

Additionally, even after all this was addressed, the greedily-automatic nature of the various `guac_common_ssh_destroy_*()` functions lead to possible double-free corruption if a user object was reused for multiple SSH sessions (as legitimately done by the main, non-common SSH client). All  common SSH objects must now be explicitly destroyed.