### PR TITLE
GUAC-515: Automatically create RDP drive path if requested.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -11,3 +11,4 @@ Felipe Weckx <felipe@weckx.net>
 Ruggero Vecchio <ruggero.vecchio@datev.it>
 Denis Bernacci <dbernaci@hotmail.com>
 Frode Langelo <frode@skytap.com>
+Daryl Borth <dborth@gmail.com>

--- a/src/protocols/rdp/client.c
+++ b/src/protocols/rdp/client.c
@@ -111,6 +111,7 @@ const char* GUAC_CLIENT_ARGS[] = {
     "enable-printing",
     "enable-drive",
     "drive-path",
+    "create-drive-path",
     "console",
     "console-audio",
     "server-layout",
@@ -158,6 +159,7 @@ enum RDP_ARGS_IDX {
     IDX_ENABLE_PRINTING,
     IDX_ENABLE_DRIVE,
     IDX_DRIVE_PATH,
+    IDX_CREATE_DRIVE_PATH,
     IDX_CONSOLE,
     IDX_CONSOLE_AUDIO,
     IDX_SERVER_LAYOUT,
@@ -303,7 +305,8 @@ BOOL rdp_freerdp_pre_connect(freerdp* instance) {
     /* Load filesystem if drive enabled */
     if (guac_client_data->settings.drive_enabled) {
         guac_client_data->filesystem =
-            guac_rdp_fs_alloc(client, guac_client_data->settings.drive_path);
+            guac_rdp_fs_alloc(client, guac_client_data->settings.drive_path,
+                    guac_client_data->settings.create_drive_path);
         client->file_handler = guac_rdp_upload_file_handler;
     }
 
@@ -772,6 +775,9 @@ int guac_client_init(guac_client* client, int argc, char** argv) {
         (strcmp(argv[IDX_ENABLE_DRIVE], "true") == 0);
 
     guac_client_data->settings.drive_path = strdup(argv[IDX_DRIVE_PATH]);
+
+    guac_client_data->settings.create_drive_path =
+        (strcmp(argv[IDX_CREATE_DRIVE_PATH], "true") == 0);
 
     /* Store client data */
     guac_client_data->rdp_inst = rdp_inst;

--- a/src/protocols/rdp/rdp_fs.c
+++ b/src/protocols/rdp/rdp_fs.c
@@ -40,7 +40,22 @@
 #include <guacamole/object.h>
 #include <guacamole/pool.h>
 
-guac_rdp_fs* guac_rdp_fs_alloc(guac_client* client, const char* drive_path) {
+guac_rdp_fs* guac_rdp_fs_alloc(guac_client* client, const char* drive_path, int create_drive_path) {
+
+    /* Create drive path if it does not exist */
+    if (create_drive_path) {
+        guac_client_log(client, GUAC_LOG_DEBUG,
+               "%s: Creating directory \"%s\".",
+               __func__, drive_path);
+
+        if (mkdir(drive_path, S_IRWXU)) {
+            if (errno != EEXIST) {
+                guac_client_log(client, GUAC_LOG_DEBUG,
+                        "%s: mkdir() failed: %s",
+                        __func__, strerror(errno));
+            }
+        }
+    }
 
     guac_rdp_fs* fs = malloc(sizeof(guac_rdp_fs));
 

--- a/src/protocols/rdp/rdp_fs.c
+++ b/src/protocols/rdp/rdp_fs.c
@@ -40,20 +40,20 @@
 #include <guacamole/object.h>
 #include <guacamole/pool.h>
 
-guac_rdp_fs* guac_rdp_fs_alloc(guac_client* client, const char* drive_path, int create_drive_path) {
+guac_rdp_fs* guac_rdp_fs_alloc(guac_client* client, const char* drive_path,
+        int create_drive_path) {
 
     /* Create drive path if it does not exist */
     if (create_drive_path) {
         guac_client_log(client, GUAC_LOG_DEBUG,
-               "%s: Creating directory \"%s\".",
+               "%s: Creating directory \"%s\" if necessary.",
                __func__, drive_path);
 
-        if (mkdir(drive_path, S_IRWXU)) {
-            if (errno != EEXIST) {
-                guac_client_log(client, GUAC_LOG_DEBUG,
-                        "%s: mkdir() failed: %s",
-                        __func__, strerror(errno));
-            }
+        /* Log error if directory creation fails */
+        if (mkdir(drive_path, S_IRWXU) && errno != EEXIST) {
+            guac_client_log(client, GUAC_LOG_ERROR,
+                    "Unable to create directory \"%s\": %s",
+                    drive_path, strerror(errno));
         }
     }
 

--- a/src/protocols/rdp/rdp_fs.c
+++ b/src/protocols/rdp/rdp_fs.c
@@ -35,6 +35,7 @@
 #include <string.h>
 #include <sys/stat.h>
 #include <sys/statvfs.h>
+#include <sys/types.h>
 #include <unistd.h>
 
 #include <guacamole/object.h>

--- a/src/protocols/rdp/rdp_fs.h
+++ b/src/protocols/rdp/rdp_fs.h
@@ -325,7 +325,7 @@ typedef struct guac_rdp_fs_info {
 /**
  * Allocates a new filesystem given a root path.
  */
-guac_rdp_fs* guac_rdp_fs_alloc(guac_client* client, const char* drive_path);
+guac_rdp_fs* guac_rdp_fs_alloc(guac_client* client, const char* drive_path, int create_drive_path);
 
 /**
  * Frees the given filesystem.

--- a/src/protocols/rdp/rdp_settings.h
+++ b/src/protocols/rdp/rdp_settings.h
@@ -156,6 +156,11 @@ typedef struct guac_rdp_settings {
     char* drive_path;
 
     /**
+     * Whether to automatically create the local system path if it does not exist.
+     */
+    int create_drive_path;
+
+    /**
      * Whether this session is a console session.
      */
     int console;

--- a/src/protocols/rdp/rdp_settings.h
+++ b/src/protocols/rdp/rdp_settings.h
@@ -156,7 +156,8 @@ typedef struct guac_rdp_settings {
     char* drive_path;
 
     /**
-     * Whether to automatically create the local system path if it does not exist.
+     * Whether to automatically create the local system path if it does not
+     * exist.
      */
     int create_drive_path;
 


### PR DESCRIPTION
This change merges (and rebases) the changes made with #33. Additionally, I have modified the automatic creation of drive path such that any errors in creation are logged at the error level, rather than at debug level.