### PR TITLE
GUAC-240: Implement support for JPEG instruction.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -53,6 +53,10 @@ AC_CHECK_LIB([m], [cos],
 AC_CHECK_LIB([png], [png_write_png], [PNG_LIBS=-lpng],
              AC_MSG_ERROR("libpng is required for writing png messages"))
 
+# libjpeg
+AC_CHECK_LIB([jpeg], [jpeg_start_compress], [JPEG_LIBS=-ljpeg],
+             AC_MSG_ERROR("libjpeg is required for writing jpeg messages"))
+
 # Cairo
 AC_CHECK_LIB([cairo], [cairo_create], [CAIRO_LIBS=-lcairo],
              AC_MSG_ERROR("Cairo is required for drawing instructions"))
@@ -87,6 +91,7 @@ AC_CHECK_LIB([wsock32], [main])
 AC_SUBST(LIBADD_DLOPEN)
 AC_SUBST(MATH_LIBS)
 AC_SUBST(PNG_LIBS)
+AC_SUBST(JPEG_LIBS)
 AC_SUBST(CAIRO_LIBS)
 AC_SUBST(PTHREAD_LIBS)
 AC_SUBST(UUID_LIBS)

--- a/src/libguac/Makefile.am
+++ b/src/libguac/Makefile.am
@@ -97,11 +97,11 @@ libguac_la_CFLAGS = \
 libguac_la_LDFLAGS =    \
     -version-info 9:0:0 \
     @CAIRO_LIBS@        \
+    @JPEG_LIBS@         \
     @PNG_LIBS@          \
     @PTHREAD_LIBS@      \
     @UUID_LIBS@         \
-    @VORBIS_LIBS@	\
-    @JPEG_LIBS@
+    @VORBIS_LIBS@
 
 libguac_la_LIBADD = \
     @LIBADD_DLOPEN@ 

--- a/src/libguac/Makefile.am
+++ b/src/libguac/Makefile.am
@@ -100,8 +100,8 @@ libguac_la_LDFLAGS =    \
     @PNG_LIBS@          \
     @PTHREAD_LIBS@      \
     @UUID_LIBS@         \
-    @VORBIS_LIBS@
+    @VORBIS_LIBS@	\
+    @JPEG_LIBS@
 
 libguac_la_LIBADD = \
     @LIBADD_DLOPEN@ 
-

--- a/src/libguac/guacamole/protocol.h
+++ b/src/libguac/guacamole/protocol.h
@@ -637,11 +637,15 @@ int guac_protocol_send_png(guac_socket* socket, guac_composite_mode mode,
  * @param surface
  *     A cairo surface containing the image data to send.
  * 
+ * @param quality
+ *     JPEG image quality.
+ * 
  * @return
  *     Zero on success, non-zero on error.
  */
 int guac_protocol_send_jpeg(guac_socket* socket, guac_composite_mode mode,
-        const guac_layer* layer, int x, int y, cairo_surface_t* surface);
+        const guac_layer* layer, int x, int y, cairo_surface_t* surface,
+        int quality);
 
 /**
  * Sends a pop instruction over the given guac_socket connection.

--- a/src/libguac/guacamole/protocol.h
+++ b/src/libguac/guacamole/protocol.h
@@ -613,6 +613,37 @@ int guac_protocol_send_png(guac_socket* socket, guac_composite_mode mode,
         const guac_layer* layer, int x, int y, cairo_surface_t* surface);
 
 /**
+ * Sends a jpeg instruction over the given guac_socket connection. The JPEG image
+ * data given will be automatically base64-encoded for transmission.
+ *
+ * If an error occurs sending the instruction, a non-zero value is
+ * returned, and guac_error is set appropriately.
+ *
+ * @param socket
+ *     The guac_socket connection to use.
+ * 
+ * @param mode
+ *     The composite mode to use.
+ * 
+ * @param layer
+ *     The destination layer.
+ * 
+ * @param x
+ *     The destination X coordinate.
+ * 
+ * @param y
+ *     The destination Y coordinate.
+ * 
+ * @param surface
+ *     A cairo surface containing the image data to send.
+ * 
+ * @return
+ *     Zero on success, non-zero on error.
+ */
+int guac_protocol_send_jpeg(guac_socket* socket, guac_composite_mode mode,
+        const guac_layer* layer, int x, int y, cairo_surface_t* surface);
+
+/**
  * Sends a pop instruction over the given guac_socket connection.
  *
  * If an error occurs sending the instruction, a non-zero value is

--- a/src/libguac/protocol.c
+++ b/src/libguac/protocol.c
@@ -85,10 +85,14 @@ ssize_t __guac_socket_write_length_double(guac_socket* socket, double d) {
  * @param surface
  *     A cairo surface containing the image data to send. 
  * 
+ * @param quality
+ *     JPEG image quality.
+ * 
  * @return
  *     Zero on success, non-zero on error.
  */
-static int __guac_socket_write_length_jpeg(guac_socket* socket, cairo_surface_t* surface) {
+static int __guac_socket_write_length_jpeg(guac_socket* socket, 
+        cairo_surface_t* surface, int quality) {
 
     /* Get image surface properties and data */
     cairo_format_t format = cairo_image_surface_get_format(surface);
@@ -99,7 +103,6 @@ static int __guac_socket_write_length_jpeg(guac_socket* socket, cairo_surface_t*
         return -1;
     }
 
-    int quality = 80; /* JPEG compression quality setting */
     int width = cairo_image_surface_get_width(surface);
     int height = cairo_image_surface_get_height(surface);
     int stride = cairo_image_surface_get_stride(surface);
@@ -1181,7 +1184,8 @@ int guac_protocol_send_pipe(guac_socket* socket, const guac_stream* stream,
 }
 
 int guac_protocol_send_jpeg(guac_socket* socket, guac_composite_mode mode,
-        const guac_layer* layer, int x, int y, cairo_surface_t* surface) {
+        const guac_layer* layer, int x, int y, cairo_surface_t* surface,
+        int quality) {
 
     int ret_val;
 
@@ -1196,7 +1200,7 @@ int guac_protocol_send_jpeg(guac_socket* socket, guac_composite_mode mode,
         || guac_socket_write_string(socket, ",")
         || __guac_socket_write_length_int(socket, y)
         || guac_socket_write_string(socket, ",")
-        || __guac_socket_write_length_jpeg(socket, surface)
+        || __guac_socket_write_length_jpeg(socket, surface, quality)
         || guac_socket_write_string(socket, ";");
 
     guac_socket_instruction_end(socket);

--- a/src/libguac/protocol.c
+++ b/src/libguac/protocol.c
@@ -159,7 +159,7 @@ static int __guac_socket_write_length_jpeg(guac_socket* socket,
         /* In Turbo JPEG we can use the raw BGRx scanline  */
         row_pointer[0] = &data[row_offset];
 #else
-        /* For standard JOEG libraries we have to convert the
+        /* For standard JPEG libraries we have to convert the
          * scanline from 24 bit (4 byte) BGRx to 24 bit (3 byte) RGB */
         unsigned char *inptr = data + row_offset;
         unsigned char *outptr = scanline_data;


### PR DESCRIPTION
Changes picked and rebased from #62 to reduce overall scope. These changes add support for the new `jpeg` instruction through the `guac_protocol_send_jpeg()` function, and add the necessary JPEG dependencies to the build.