### PR TITLE
GUAC-1285: Add support for libjpeg6b

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -110,6 +110,13 @@ AC_CHECK_DECL([cairo_format_stride_for_width],
                [Whether cairo_format_stride_for_width() is defined])],,
 	[#include <cairo/cairo.h>])
 
+AC_CHECK_DECL([jpeg_mem_dest],
+    [AC_DEFINE([HAVE_JPEG_MEM_DEST],,
+               [Whether jpeg_mem_dest() is defined])],,
+    [#include <stddef.h>
+     #include <stdio.h>
+     #include <jpeglib.h>])
+
 # Typedefs
 AC_TYPE_SIZE_T
 AC_TYPE_SSIZE_T


### PR DESCRIPTION
Older versions of libjpeg, such as version 6b, lack the `jpeg_mem_dest()` function required by Guacamole as of recent [GUAC-240](https://glyptodon.org/jira/browse/GUAC-240) changes (see c27e299). This breaks the Guacamole build on several platforms, including CentOS 6.

This change adds support for older versions of libjpeg by providing an internal implementation of `jpeg_mem_dest()` if libjpeg does not provide its own.