### PR TITLE
GUAC-1290: Increase VNC frame timeout to 10ms

### DIFF
--- a/src/protocols/vnc/client.h
+++ b/src/protocols/vnc/client.h
@@ -53,7 +53,7 @@
  * milliseconds. If the server is silent for at least this amount of time, the
  * frame will be considered finished.
  */
-#define GUAC_VNC_FRAME_TIMEOUT 0
+#define GUAC_VNC_FRAME_TIMEOUT 10
 
 /**
  * The number of milliseconds to wait between connection attempts.


### PR DESCRIPTION
This change increases the `GUAC_VNC_FRAME_TIMEOUT` from 0ms to 10ms so more VNC messages can be handled each frame.