### PR TITLE
GUAC-1296: Send IAC BRK when Pause, Break, or Ctrl+0 are pressed.

### DIFF
--- a/src/protocols/telnet/guac_handlers.c
+++ b/src/protocols/telnet/guac_handlers.c
@@ -92,7 +92,7 @@ int guac_telnet_client_key_handler(guac_client* client, int keysym, int pressed)
        )) {
 
         /* Send IAC BRK */
-        guac_client_log(client, GUAC_LOG_DEBUG, "STUB");
+        telnet_iac(client_data->telnet, TELNET_BREAK);
 
         return 0;
     }

--- a/src/protocols/telnet/guac_handlers.c
+++ b/src/protocols/telnet/guac_handlers.c
@@ -84,6 +84,19 @@ int guac_telnet_client_key_handler(guac_client* client, int keysym, int pressed)
 
     }
 
+    /* Intercept and handle Pause / Break / Ctrl+0 as "IAC BRK" */
+    if (pressed && (
+                keysym == 0xFF13                  /* Pause */
+             || keysym == 0xFF6B                  /* Break */
+             || (term->mod_ctrl && keysym == '0') /* Ctrl + 0 */
+       )) {
+
+        /* Send IAC BRK */
+        guac_client_log(client, GUAC_LOG_DEBUG, "STUB");
+
+        return 0;
+    }
+
     /* Send key */
     guac_terminal_send_key(term, keysym, pressed);
 


### PR DESCRIPTION
This change adds support for telnet's IAC ("interpret as command") BRK ("break"), sending IAC BRK   whenever `Pause`, `Break`, or `Ctrl`+`0` are pressed.

The BRK command is different from control codes like `^C` and has different semantics. Though usually initiated using the keyboard, including our implementation, it is not technically keyboard input.

Traditionally, sending a break meant leaving the data line in a logical zero state for a prescribed amount of time (somewhere on the order of a few hundred milliseconds). Telnet, lacking such a data line, uses its own IAC system to accomplish this.

When connected to a Linux terminal, receiving BRK causes SIGINT or SIGBREAK to be sent to the child processes of that terminal. Low-level hardware which supports telnet also often assigns purpose to telnet "break".