### PR TITLE
GUAC-1297: Remove indentation / use tabs where required by Makefile standard.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -42,27 +42,27 @@ SUBDIRS =       \
     tests
 
 if ENABLE_COMMON_SSH
-    SUBDIRS += src/common-ssh
+SUBDIRS += src/common-ssh
 endif
 
 if ENABLE_TERMINAL
-    SUBDIRS += src/terminal
+SUBDIRS += src/terminal
 endif
 
 if ENABLE_RDP
-    SUBDIRS += src/protocols/rdp
+SUBDIRS += src/protocols/rdp
 endif
 
 if ENABLE_SSH
-    SUBDIRS += src/protocols/ssh
+SUBDIRS += src/protocols/ssh
 endif
 
 if ENABLE_TELNET
-    SUBDIRS += src/protocols/telnet
+SUBDIRS += src/protocols/telnet
 endif
 
 if ENABLE_VNC
-    SUBDIRS += src/protocols/vnc
+SUBDIRS += src/protocols/vnc
 endif
 
 EXTRA_DIST =     \

--- a/src/guacd/Makefile.am
+++ b/src/guacd/Makefile.am
@@ -77,7 +77,7 @@ initdir = @init_dir@
 init_SCRIPTS = init.d/guacd
 
 init.d/guacd: init.d/guacd.in
-    sed -e 's,[@]sbindir[@],$(sbindir),g' < init.d/guacd.in > init.d/guacd
-    chmod +x init.d/guacd
+	sed -e 's,[@]sbindir[@],$(sbindir),g' < init.d/guacd.in > init.d/guacd
+	chmod +x init.d/guacd
 endif
 


### PR DESCRIPTION
Each `Makefile` is generally free to use whatever whitespace it likes .... *EXCEPT* preceding the commands within a recipe, where tab characters are strictly required by the `Makefile` syntax. Necessary tabs were replaced with spaces in commit c199cfc, breaking the build on platforms where this is enforced.

This PR changes those spaces back to tabs, and removes the indent entirely in a few cases where it technically should be absent (between automake macros).