### PR TITLE
GUAC-1280: Bump version numbers to 0.9.8. Update libtool versioning.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2013 Glyptodon LLC
+# Copyright (C) 2015 Glyptodon LLC
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -21,7 +21,7 @@
 #
 
 AC_PREREQ([2.61])
-AC_INIT([guacamole-server], [0.9.7])
+AC_INIT([guacamole-server], [0.9.8])
 AM_INIT_AUTOMAKE([-Wall -Werror foreign subdir-objects])
 AM_SILENT_RULES([yes])
 

--- a/doc/Doxyfile
+++ b/doc/Doxyfile
@@ -31,7 +31,7 @@ PROJECT_NAME           = libguac
 # This could be handy for archiving the generated documentation or
 # if some version control system is used.
 
-PROJECT_NUMBER         = 0.9.7
+PROJECT_NUMBER         = 0.9.8
 
 # The OUTPUT_DIRECTORY tag is used to specify the (relative or absolute)
 # base path where the generated documentation will be put.

--- a/src/guacd/man/guacd.8
+++ b/src/guacd/man/guacd.8
@@ -1,4 +1,4 @@
-.TH guacd 8 "8 Jun 2015" "version 0.9.7" "Guacamole"
+.TH guacd 8 "4 Sep 2015" "version 0.9.8" "Guacamole"
 .
 .SH NAME
 guacd \- Guacamole proxy daemon

--- a/src/guacd/man/guacd.conf.5
+++ b/src/guacd/man/guacd.conf.5
@@ -1,4 +1,4 @@
-.TH guacd.conf 5 "8 Jun 2015" "version 0.9.7" "Guacamole"
+.TH guacd.conf 5 "4 Sep 2015" "version 0.9.8" "Guacamole"
 .
 .SH NAME
 /etc/guacamole/guacd.conf \- Configuration file for guacd

--- a/src/libguac/Makefile.am
+++ b/src/libguac/Makefile.am
@@ -98,13 +98,13 @@ endif
 libguac_la_CFLAGS = \
     -Werror -Wall -pedantic -Iguacamole
 
-libguac_la_LDFLAGS =    \
-    -version-info 9:0:0 \
-    @CAIRO_LIBS@        \
-    @JPEG_LIBS@         \
-    @PNG_LIBS@          \
-    @PTHREAD_LIBS@      \
-    @UUID_LIBS@         \
+libguac_la_LDFLAGS =     \
+    -version-info 10:0:0 \
+    @CAIRO_LIBS@         \
+    @JPEG_LIBS@          \
+    @PNG_LIBS@           \
+    @PTHREAD_LIBS@       \
+    @UUID_LIBS@          \
     @VORBIS_LIBS@
 
 libguac_la_LIBADD = \


### PR DESCRIPTION
This change bumps the version of guacamole-server to 0.9.8 to match the upcoming release. The libtool versioning must be bumped up a full release number (without backward compatibility) as this release removes `guac_protocol_send_png()` in favor of the more generic (and faster and more efficient) `guac_protocol_send_img()`.

Any previous usages of `guac_protocol_send_png()` should be replaced with `guac_client_stream_png()` which leverages `guac_protocol_send_img()` behind the scenes. This release of libguac is otherwise completely API-compatible with 0.9.7, though not ABI-compatible.