### PR TITLE
GUAC-427: Avoid sending silence received from PulseAudio.

### DIFF
--- a/src/protocols/vnc/pulse.c
+++ b/src/protocols/vnc/pulse.c
@@ -45,7 +45,7 @@ static int guac_pa_is_silence(const void* buffer, size_t length) {
 
     int i;
 
-    unsigned char* current = (unsigned char*) buffer;
+    const unsigned char* current = (const unsigned char*) buffer;
 
     /* For each byte in buffer */
     for (i = 0; i < length; i++) {


### PR DESCRIPTION
PulseAudio has the unfortunate habit of constantly streaming data, even when that data is nothing but silence (null bytes). This change works around this issue by only sending data received from PulseAudio if it is *not* silence, or if data is present in the audio buffer that will not be flushed otherwise.