### PR TITLE
GUAC-1344: Add TLS-PSK support (RFC 4279)

### DIFF
--- a/src/guacd/conf-args.c
+++ b/src/guacd/conf-args.c
@@ -35,7 +35,7 @@ int guacd_conf_parse_args(guacd_config* config, int argc, char** argv) {
 
     /* Parse arguments */
     int opt;
-    while ((opt = getopt(argc, argv, "l:b:p:L:C:K:f")) != -1) {
+    while ((opt = getopt(argc, argv, "l:b:p:L:C:K:P:f")) != -1) {
 
         /* -l: Bind port */
         if (opt == 'l') {
@@ -86,8 +86,16 @@ int guacd_conf_parse_args(guacd_config* config, int argc, char** argv) {
             free(config->key_file);
             config->key_file = strdup(optarg);
         }
+
+        /* -P TLS-PSK peer*/
+        else if (opt == 'P') {
+            if (add_psk_to_list(&config->psk_list, optarg)) {
+                fprintf(stderr, "Failed to add PSK peer to list.\n");
+                return 1;
+            }
+        }
 #else
-        else if (opt == 'C' || opt == 'K') {
+        else if (opt == 'C' || opt == 'K' || opt 'P') {
             fprintf(stderr,
                     "This guacd does not have SSL/TLS support compiled in.\n\n"
 
@@ -107,6 +115,7 @@ int guacd_conf_parse_args(guacd_config* config, int argc, char** argv) {
 #ifdef ENABLE_SSL
                     " [-C CERTIFICATE_FILE]"
                     " [-K PEM_FILE]"
+                    " [-P TLS_PSK_PEER]"
 #endif
                     " [-f]\n", argv[0]);
 

--- a/src/guacd/conf-args.c
+++ b/src/guacd/conf-args.c
@@ -95,7 +95,7 @@ int guacd_conf_parse_args(guacd_config* config, int argc, char** argv) {
             }
         }
 #else
-        else if (opt == 'C' || opt == 'K' || opt 'P') {
+        else if (opt == 'C' || opt == 'K' || opt == 'P') {
             fprintf(stderr,
                     "This guacd does not have SSL/TLS support compiled in.\n\n"
 

--- a/src/guacd/conf-file.c
+++ b/src/guacd/conf-file.c
@@ -38,6 +38,40 @@
 #include <fcntl.h>
 
 /**
+ * Parse string of the form [identity:key] to a PSK peer object and add
+ * to configuration list.
+ */
+int add_psk_to_list(tls_psk** list, const char* psk) {
+    char *colon = strchr(psk, ':');
+    if (colon == NULL) {
+        guacd_conf_parse_error = "Failed to parse PSK peer entry.";
+        return 1;
+    }
+
+    tls_psk* temp = (tls_psk*) malloc(sizeof(struct tls_psk));
+    if (temp == NULL) {
+        guacd_conf_parse_error = "Memory allocation failure.";
+        return 1;
+    }
+
+    temp->identity = strndup(psk, colon - psk);
+    temp->key_len = strlen(colon + 1);
+    temp->key = (char*) malloc(temp->key_len);
+
+    if (temp->identity == NULL || temp->key == NULL) {
+        guacd_conf_parse_error = "Memory allocation failure.";
+        return 1;
+    }
+
+    memcpy(temp->key, colon + 1, temp->key_len);
+
+    temp->next = *list;
+    *list = temp;
+
+    return 0;
+}
+
+/**
  * Updates the configuration with the given parameter/value pair, flagging
  * errors as necessary.
  */
@@ -107,6 +141,15 @@ static int guacd_conf_callback(const char* section, const char* param, const cha
         else if (strcmp(param, "server_key") == 0) {
             free(config->key_file);
             config->key_file = strdup(value);
+            return 0;
+        }
+
+        /* PSK */
+        else if (strcmp(param, "psk_peer") == 0) {
+            if (add_psk_to_list(&config->psk_list, value)) {
+                guacd_conf_parse_error = "Failed to parse psk and add to peer list.";
+                return 1;
+            }
             return 0;
         }
 #else
@@ -187,6 +230,7 @@ guacd_config* guacd_conf_load() {
 #ifdef ENABLE_SSL
     conf->cert_file = NULL;
     conf->key_file = NULL;
+    conf->psk_list = NULL;
 #endif
 
     /* Read configuration from file */

--- a/src/guacd/conf-file.h
+++ b/src/guacd/conf-file.h
@@ -28,6 +28,16 @@
 #include <guacamole/client.h>
 
 /**
+ * TLS-PSK object.
+ */
+typedef struct tls_psk {
+    char* identity;
+    char* key;
+    unsigned int key_len;
+    struct tls_psk* next;
+} tls_psk;
+
+/**
  * The contents of a guacd configuration file.
  */
 typedef struct guacd_config {
@@ -62,6 +72,11 @@ typedef struct guacd_config {
      * SSL private key file.
      */
     char* key_file;
+
+    /**
+     * PSK list
+     */
+    tls_psk* psk_list;
 #endif
 
     /**
@@ -84,5 +99,10 @@ int guacd_conf_parse_file(guacd_config* conf, int fd);
  */
 guacd_config* guacd_conf_load();
 
+/**
+ * Parse a string of the form "identity:pre-shared-key" and add a corresponding
+ * object to the list of PSK peers.
+ */
+int add_psk_to_list(tls_psk** list, const char* psk);
 #endif
 

--- a/src/guacd/daemon.c
+++ b/src/guacd/daemon.c
@@ -392,6 +392,7 @@ int daemonize() {
 
 }
 
+#ifdef ENABLE_SSL
 unsigned int check_psk(SSL *ssl, const char *id, unsigned char *key, unsigned int max_key_len) {
     tls_psk* list = (tls_psk*) SSL_get_app_data(ssl);
     if (list == NULL) {
@@ -418,6 +419,7 @@ unsigned int check_psk(SSL *ssl, const char *id, unsigned char *key, unsigned in
 
     return 0;
 }
+#endif
 
 int main(int argc, char* argv[]) {
 

--- a/src/guacd/daemon.c
+++ b/src/guacd/daemon.c
@@ -392,6 +392,33 @@ int daemonize() {
 
 }
 
+unsigned int check_psk(SSL *ssl, const char *id, unsigned char *key, unsigned int max_key_len) {
+    tls_psk* list = (tls_psk*) SSL_get_app_data(ssl);
+    if (list == NULL) {
+        guacd_log(GUAC_LOG_ERROR, "TLS-PSK no available PSK list.");
+        return 0;
+    }
+
+    while (list) {
+        if (strcmp(id, list->identity) == 0) {
+            guacd_log(GUAC_LOG_INFO,"TLS-PSK found entry for identity: %s.", id);
+
+            if (list->key_len > max_key_len) {
+                guacd_log(GUAC_LOG_ERROR, "TLS-PSK insuffient buffer provided by TLS engine "
+                          "required (%d), provided (%d).", list->key_len, max_key_len);
+                return 0;
+            }
+            memcpy(key, list->key, list->key_len);
+            return list->key_len;
+        }
+        list = list->next;
+    }
+
+    guacd_log(GUAC_LOG_INFO,"TLS-PSK identity %s not found.", id);
+
+    return 0;
+}
+
 int main(int argc, char* argv[]) {
 
     /* Server */
@@ -504,7 +531,7 @@ int main(int argc, char* argv[]) {
 
 #ifdef ENABLE_SSL
     /* Init SSL if enabled */
-    if (config->key_file != NULL || config->cert_file != NULL) {
+    if (config->key_file != NULL || config->cert_file != NULL || config->psk_list != NULL) {
 
         /* Init SSL */
         guacd_log(GUAC_LOG_INFO, "Communication will require SSL/TLS.");
@@ -533,6 +560,13 @@ int main(int argc, char* argv[]) {
         }
         else
             guacd_log(GUAC_LOG_WARNING, "No certificate file given - SSL/TLS may not work.");
+
+       /* Set PSK callback if used */
+       if (config->psk_list != NULL) {
+            guacd_log(GUAC_LOG_INFO, "Using TLS-PSK.");
+            SSL_CTX_set_app_data(ssl_context, config->psk_list);
+            SSL_CTX_set_psk_server_callback(ssl_context, check_psk);
+        }
 
     }
 #endif

--- a/src/guacd/daemon.c
+++ b/src/guacd/daemon.c
@@ -561,11 +561,17 @@ int main(int argc, char* argv[]) {
         else
             guacd_log(GUAC_LOG_WARNING, "No certificate file given - SSL/TLS may not work.");
 
-       /* Set PSK callback if used */
+       /* Set PSK callback if requested */
        if (config->psk_list != NULL) {
             guacd_log(GUAC_LOG_INFO, "Using TLS-PSK.");
             SSL_CTX_set_app_data(ssl_context, config->psk_list);
             SSL_CTX_set_psk_server_callback(ssl_context, check_psk);
+
+            /* If PSK was specify we only allow PSK ciphers to enforce mutual auth */
+            if (!SSL_CTX_set_cipher_list(ssl_context, "PSK")) {
+                guacd_log(GUAC_LOG_ERROR, "No PSK ciphers available.");
+                exit(EXIT_FAILURE);
+            }
         }
 
     }

--- a/src/guacd/socket-ssl.c
+++ b/src/guacd/socket-ssl.c
@@ -127,6 +127,7 @@ guac_socket* guac_socket_open_secure(SSL_CTX* context, int fd) {
     data->context = context;
     data->ssl = SSL_new(context);
     SSL_set_fd(data->ssl, fd);
+    SSL_set_app_data(data->ssl, SSL_CTX_get_app_data(context));
 
     /* Accept SSL connection, handle errors */
     if (SSL_accept(data->ssl) <= 0) {


### PR DESCRIPTION
This allows for mutual authentication with pre-shared keys instead
of certificates (PSK and DHE-PSK) or in addition to regular TLS with
certificates (RSA-PSK).

Adds configuration entry 'psk_peer' (ssl) and corresponding '-P' command
line argument which take a PSK peer in the form of [identity:key].

Multiple occurrences of PSK peers are allowed (the key is searched
according to the identity provided by the client).

Use case:
Given that the authorization is done by the guacamole-client (java) component, there seem to be a need for mutual authentication between guacd and its clients so not anyone could use guacd but only authenticated peers (especially when they do not run on the same machine).

This could allow to have guacd with one internal leg to communicate with the servers and one leg on DMZ on which is accepts guacd clients but only authenticated ones.

Client side:
I've also looked for the client side matching improvement but so far the only example I could find to use TLS-PSK are based on bouncy-castle library, meanwhile 'stunnel' tool could be used on client side (in PSK client mode).

Thanks for this great and open software!