### PR TITLE
GUAC-240: Ensure initialization of last_pixel is obvious.

### DIFF
--- a/src/common/guac_surface.c
+++ b/src/common/guac_surface.c
@@ -343,25 +343,27 @@ static int __guac_common_surface_png_optimality(guac_common_surface* surface,
     /* Get buffer from surface */
     unsigned char* buffer = surface->buffer + rect->y * stride + rect->x * 4;
 
+    /* Image must be at least 1x1 */
+    if (width < 1 || height < 1)
+        return 0;
+
     /* For each row */
     for (y = 0; y < height; y++) {
 
-        uint32_t last_pixel;
         uint32_t* row = (uint32_t*) buffer;
+        uint32_t last_pixel = *(row++) | 0xFF000000;
 
         /* For each pixel in current row */
-        for (x = 0; x < width; x++) {
+        for (x = 1; x < width; x++) {
 
             /* Get next pixel */
             uint32_t current_pixel = *(row++) | 0xFF000000;
 
             /* Update same/different counts according to pixel value */
-            if (x != 0) {
-                if (current_pixel == last_pixel)
-                    num_same++;
-                else
-                    num_different++;
-            }
+            if (current_pixel == last_pixel)
+                num_same++;
+            else
+                num_different++;
 
             last_pixel = current_pixel;
 


### PR DESCRIPTION
From a CI build of the recent merge of the experimental branch to master:

    guac_surface.c: In function 'guac_common_surface_flush':
    guac_surface.c:360:20: error: 'last_pixel' may be used uninitialized in this function [-Werror=maybe-uninitialized]
    guac_surface.c:349:18: note: 'last_pixel' was declared here

This is actually untrue - it is impossible for `last_pixel` to be uninitialized here, but the compiler in use in this build environment differs from the compiler used in the past, and this particular warning is a little less selective. For what it's worth, even the function name is incorrect here - the lines in question are actually within the function `__guac_common_surface_png_optimality()`.

I've modified things such that `last_pixel` is obviously initialized, without making that initialization unnecessary.