### PR TITLE
GUAC-1305: Add image mimetypes to Guacamole protocol handshake.

### DIFF
--- a/src/libguac/guacamole/client.h
+++ b/src/libguac/guacamole/client.h
@@ -74,6 +74,13 @@ struct guac_client_info {
     const char** video_mimetypes;
 
     /**
+     * NULL-terminated array of client-supported image mimetypes. Though all
+     * supported image mimetypes will be listed here, it can be safely assumed
+     * that all clients will support at least "image/png" and "image/jpeg".
+     */ 
+    const char** image_mimetypes;
+
+    /**
      * The DPI of the physical remote display if configured for the optimal
      * width/height combination described here. This need not be honored by
      * a client plugin implementation, but if the underlying protocol of the


### PR DESCRIPTION
This change adds a new instruction, `image`, to the Guacamole protocol handshake. This instruction lists the image formats supported by the client side. It is safe to assume that this list will contain `image/png` and `image/jpeg`, though a properly-functioning client implementation will still perform these checks and include the mimetypes in the handshake anyway.