### PR TITLE
GUAC-1305: Support lossless WebP within encoder.

### DIFF
--- a/src/common/guac_surface.c
+++ b/src/common/guac_surface.c
@@ -1340,7 +1340,7 @@ static void __guac_common_surface_flush_to_webp(guac_common_surface* surface) {
         /* Send WebP for rect */
         guac_client_stream_webp(surface->client, socket, GUAC_COMP_OVER, layer,
                 surface->dirty_rect.x, surface->dirty_rect.y, rect,
-                GUAC_SURFACE_WEBP_IMAGE_QUALITY);
+                GUAC_SURFACE_WEBP_IMAGE_QUALITY, 0);
         cairo_surface_destroy(rect);
         surface->realized = 1;
 

--- a/src/libguac/client.c
+++ b/src/libguac/client.c
@@ -425,7 +425,7 @@ void guac_client_stream_jpeg(guac_client* client, guac_socket* socket,
 
 void guac_client_stream_webp(guac_client* client, guac_socket* socket,
         guac_composite_mode mode, const guac_layer* layer, int x, int y,
-        cairo_surface_t* surface, int quality) {
+        cairo_surface_t* surface, int quality, int lossless) {
 
 #ifdef ENABLE_WEBP
     /* Allocate new stream for image */
@@ -435,7 +435,7 @@ void guac_client_stream_webp(guac_client* client, guac_socket* socket,
     guac_protocol_send_img(socket, stream, mode, layer, "image/webp", x, y);
 
     /* Write WebP data */
-    guac_webp_write(socket, stream, surface, quality);
+    guac_webp_write(socket, stream, surface, quality, lossless);
 
     /* Terminate stream */
     guac_protocol_send_end(socket, stream);

--- a/src/libguac/encode-webp.c
+++ b/src/libguac/encode-webp.c
@@ -166,7 +166,7 @@ static int guac_webp_stream_write(const uint8_t* data, size_t data_size,
 }
 
 int guac_webp_write(guac_socket* socket, guac_stream* stream,
-        cairo_surface_t* surface, int quality) {
+        cairo_surface_t* surface, int quality, int lossless) {
 
     guac_webp_stream_writer writer;
     WebPPicture picture;
@@ -195,7 +195,7 @@ int guac_webp_write(guac_socket* socket, guac_stream* stream,
         return -1;
 
     /* Add additional tuning */
-    config.lossless = 0;
+    config.lossless = lossless;
     config.quality = quality;
     config.thread_level = 1; /* Multi threaded */
     config.method = 2; /* Compression method (0=fast/larger, 6=slow/smaller) */

--- a/src/libguac/encode-webp.h
+++ b/src/libguac/encode-webp.h
@@ -44,12 +44,18 @@
  *     The Cairo surface to write to the given stream and socket as PNG blobs.
  *
  * @param quality
- *     The WebP image quality to use.
+ *     The WebP image quality to use. For lossy images, larger values indicate
+ *     improving quality at the expense of larger file size. For lossless
+ *     images, this dictates the quality of compression, with larger values
+ *     producing smaller files at the expense of speed.
+ *
+ * @param lossless
+ *     Zero for a lossy image, non-zero for lossless.
  *
  * @return
  *     Zero if the encoding operation is successful, non-zero otherwise.
  */
 int guac_webp_write(guac_socket* socket, guac_stream* stream,
-        cairo_surface_t* surface, int quality);
+        cairo_surface_t* surface, int quality, int lossless);
 
 #endif

--- a/src/libguac/guacamole/client.h
+++ b/src/libguac/guacamole/client.h
@@ -737,12 +737,18 @@ void guac_client_stream_jpeg(guac_client* client, guac_socket* socket,
  *     A Cairo surface containing the image data to be streamed.
  *
  * @param quality
- *     The WebP image quality, which must be an integer value between 0 and
- *     100 inclusive.
+ *     The WebP image quality, which must be an integer value between 0 and 100
+ *     inclusive. For lossy images, larger values indicate improving quality at
+ *     the expense of larger file size. For lossless images, this dictates the
+ *     quality of compression, with larger values producing smaller files at
+ *     the expense of speed.
+ *
+ * @param lossless
+ *     Zero to encode a lossy image, non-zero to encode losslessly.
  */
 void guac_client_stream_webp(guac_client* client, guac_socket* socket,
         guac_composite_mode mode, const guac_layer* layer, int x, int y,
-        cairo_surface_t* surface, int quality);
+        cairo_surface_t* surface, int quality, int lossless);
 
 /**
  * Returns whether the given client supports WebP. If the client does not


### PR DESCRIPTION
We can't use WebP instead of PNG as there are quite a few cases where PNG is *far* better, and those cases occur extremely frequently in typical use of guac, but it does make sense to at least provide the support at an API level.

I made these changes expecting the WebP vs. PNG experiment to come out in favor of WebP. This did not happen, but the changes are still sound.