### PR TITLE
GUAC-1305: Copy mimetypes - do not just point instruction storage

### DIFF
--- a/src/libguac/client.c
+++ b/src/libguac/client.c
@@ -451,7 +451,7 @@ void guac_client_stream_webp(guac_client* client, guac_socket* socket,
 int guac_client_supports_webp(guac_client* client) {
 
 #ifdef ENABLE_WEBP
-    const char** mimetype = client->info.image_mimetypes;
+    char** mimetype = client->info.image_mimetypes;
 
     /* Search for WebP mimetype in list of supported image mimetypes */
     while (*mimetype != NULL) {

--- a/src/libguac/guacamole/client.h
+++ b/src/libguac/guacamole/client.h
@@ -65,20 +65,20 @@ struct guac_client_info {
      * NULL-terminated array of client-supported audio mimetypes. If the client
      * does not support audio at all, this will be NULL.
      */
-    const char** audio_mimetypes;
+    char** audio_mimetypes;
 
     /**
      * NULL-terminated array of client-supported video mimetypes. If the client
      * does not support video at all, this will be NULL.
      */
-    const char** video_mimetypes;
+    char** video_mimetypes;
 
     /**
      * NULL-terminated array of client-supported image mimetypes. Though all
      * supported image mimetypes will be listed here, it can be safely assumed
      * that all clients will support at least "image/png" and "image/jpeg".
      */ 
-    const char** image_mimetypes;
+    char** image_mimetypes;
 
     /**
      * The DPI of the physical remote display if configured for the optimal


### PR DESCRIPTION
The storage used for instruction arguments *cannot* be relied upon between reads. The buffers used to store instruction data are reused with subsequent read calls. For GUAC-1305, this has the effect of WebP suddenly becoming disabled later on in the connection, as the stored mimetypes no longer match.

This change copies the mimetypes received during the handshake into dynamically-allocated storage which is freed upon disconnect.