### PR TITLE
GUAC-1354: Remove duration from video instruction.

### DIFF
--- a/src/libguac/guacamole/protocol.h
+++ b/src/libguac/guacamole/protocol.h
@@ -375,15 +375,23 @@ int guac_protocol_send_end(guac_socket* socket, const guac_stream* stream);
  * If an error occurs sending the instruction, a non-zero value is
  * returned, and guac_error is set appropriately.
  *
- * @param socket The guac_socket connection to use.
- * @param stream The stream to use.
- * @param layer The destination layer.
- * @param mimetype The mimetype of the data being sent.
- * @param duration The duration of the video being sent, in milliseconds.
- * @return Zero on success, non-zero on error.
+ * @param socket
+ *     The guac_socket connection to use when sending the video instruction.
+ *
+ * @param stream
+ *     The stream to use for future video data.
+ *
+ * @param layer
+ *     The destination layer on which the streamed video should be played.
+ *
+ * @param mimetype
+ *     The mimetype of the video data which will be sent over the given stream.
+ *
+ * @return
+ *     Zero on success, non-zero on error.
  */
 int guac_protocol_send_video(guac_socket* socket, const guac_stream* stream,
-        const guac_layer* layer, const char* mimetype, double duration);
+        const guac_layer* layer, const char* mimetype);
 
 /* DRAWING INSTRUCTIONS */
 

--- a/src/libguac/protocol.c
+++ b/src/libguac/protocol.c
@@ -1074,7 +1074,7 @@ int guac_protocol_send_undefine(guac_socket* socket,
 }
 
 int guac_protocol_send_video(guac_socket* socket, const guac_stream* stream,
-        const guac_layer* layer, const char* mimetype, double duration) {
+        const guac_layer* layer, const char* mimetype) {
 
     int ret_val;
 
@@ -1086,8 +1086,6 @@ int guac_protocol_send_video(guac_socket* socket, const guac_stream* stream,
         || __guac_socket_write_length_int(socket, layer->index)
         || guac_socket_write_string(socket, ",")
         || __guac_socket_write_length_string(socket, mimetype)
-        || guac_socket_write_string(socket, ",")
-        || __guac_socket_write_length_double(socket, duration)
         || guac_socket_write_string(socket, ";");
     guac_socket_instruction_end(socket);
 


### PR DESCRIPTION
The duration is no longer needed, as the Guacamole client will play received video back immediately.