### PR TITLE
GUAC-1374: socket->__keep_alive_enabled MUST be initialized

### DIFF
--- a/src/libguac/socket.c
+++ b/src/libguac/socket.c
@@ -161,6 +161,9 @@ guac_socket* guac_socket_alloc() {
     /* Default to unsafe threading */
     socket->__threadsafe_instructions = 0;
 
+    /* No keep alive ping by default */
+    socket->__keep_alive_enabled = 0;
+
     pthread_mutexattr_init(&lock_attributes);
     pthread_mutexattr_setpshared(&lock_attributes, PTHREAD_PROCESS_SHARED);
 


### PR DESCRIPTION
The `__keep_alive_enabled` flag is used by `guac_socket` to determine whether the keep alive thread is running. The thread is disabled by default, and this flag absolutely **must** reflect that. Doing otherwise is dangerous.