### PR TITLE
GUAC-363: Add support for the RDP preconnection PDU (and thus Hyper-V)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -609,6 +609,7 @@ then
                       rdpSettings.Height,
                       rdpSettings.FastPathInput,
                       rdpSettings.FastPathOutput,
+                      rdpSettings.SendPreconnectionPdu,
                       rdpSettings.OrderSupport],
                      [rdpsettings_interface=stable],,
                      [[#include <freerdp/freerdp.h>]])

--- a/src/protocols/rdp/client.c
+++ b/src/protocols/rdp/client.c
@@ -780,9 +780,21 @@ int guac_client_init(guac_client* client, int argc, char** argv) {
     /* Preconnection ID */
     settings->preconnection_id = -1;
     if (argv[IDX_PRECONNECTION_ID][0] != '\0') {
-        settings->preconnection_id = atoi(argv[IDX_PRECONNECTION_ID]);
-        guac_client_log(client, GUAC_LOG_DEBUG,
-                "Preconnection ID: %i", settings->preconnection_id);
+
+        /* Parse preconnection ID, warn if invalid */
+        int preconnection_id = atoi(argv[IDX_PRECONNECTION_ID]);
+        if (preconnection_id < 0)
+            guac_client_log(client, GUAC_LOG_WARNING,
+                    "Ignoring invalid preconnection ID: %i",
+                    preconnection_id);
+
+        /* Otherwise, assign specified ID */
+        else {
+            settings->preconnection_id = preconnection_id;
+            guac_client_log(client, GUAC_LOG_DEBUG,
+                    "Preconnection ID: %i", settings->preconnection_id);
+        }
+
     }
 
     /* Preconnection BLOB */

--- a/src/protocols/rdp/client.c
+++ b/src/protocols/rdp/client.c
@@ -129,6 +129,8 @@ const char* GUAC_CLIENT_ARGS[] = {
     "enable-full-window-drag",
     "enable-desktop-composition",
     "enable-menu-animations",
+    "preconnection-id",
+    "preconnection-blob",
 
 #ifdef ENABLE_COMMON_SSH
     "enable-sftp",
@@ -178,6 +180,8 @@ enum RDP_ARGS_IDX {
     IDX_ENABLE_FULL_WINDOW_DRAG,
     IDX_ENABLE_DESKTOP_COMPOSITION,
     IDX_ENABLE_MENU_ANIMATIONS,
+    IDX_PRECONNECTION_ID,
+    IDX_PRECONNECTION_BLOB,
 
 #ifdef ENABLE_COMMON_SSH
     IDX_ENABLE_SFTP,
@@ -772,6 +776,33 @@ int guac_client_init(guac_client* client, int argc, char** argv) {
                 "Invalid color-depth: \"%s\". Using default of %i.",
                 argv[IDX_WIDTH], settings->color_depth);
     }
+
+    /* Preconnection ID */
+    settings->preconnection_id = -1;
+    if (argv[IDX_PRECONNECTION_ID][0] != '\0') {
+        settings->preconnection_id = atoi(argv[IDX_PRECONNECTION_ID]);
+        guac_client_log(client, GUAC_LOG_DEBUG,
+                "Preconnection ID: %i", settings->preconnection_id);
+    }
+
+    /* Preconnection BLOB */
+    settings->preconnection_blob = NULL;
+    if (argv[IDX_PRECONNECTION_BLOB][0] != '\0') {
+        settings->preconnection_blob = strdup(argv[IDX_PRECONNECTION_BLOB]);
+        guac_client_log(client, GUAC_LOG_DEBUG,
+                "Preconnection BLOB: \"%s\"", settings->preconnection_blob);
+    }
+
+#ifndef HAVE_RDPSETTINGS_SENDPRECONNECTIONPDU
+    /* Warn if support for the preconnection BLOB / ID is absent */
+    if (settings->preconnection_blob != NULL
+            || settings->preconnection_id != -1) {
+        guac_client_log(client, GUAC_LOG_WARNING,
+                "Installed version of FreeRDP lacks support for the "
+                "preconnection PDU. The specified preconnection BLOB and/or "
+                "ID will be ignored.");
+    }
+#endif
 
     /* Audio enable/disable */
     guac_client_data->settings.audio_enabled =

--- a/src/protocols/rdp/rdp_settings.c
+++ b/src/protocols/rdp/rdp_settings.c
@@ -292,6 +292,22 @@ void guac_rdp_push_settings(guac_rdp_settings* guac_settings, freerdp* rdp) {
 #endif
     }
 
+#ifdef HAVE_RDPSETTINGS_SENDPRECONNECTIONPDU
+    /* Preconnection ID */
+    if (guac_settings->preconnection_id != -1) {
+        rdp_settings->NegotiateSecurityLayer = FALSE;
+        rdp_settings->SendPreconnectionPdu = TRUE;
+        rdp_settings->PreconnectionId = guac_settings->preconnection_id;
+    }
+
+    /* Preconnection BLOB */
+    if (guac_settings->preconnection_blob != NULL) {
+        rdp_settings->NegotiateSecurityLayer = FALSE;
+        rdp_settings->SendPreconnectionPdu = TRUE;
+        rdp_settings->PreconnectionBlob = guac_settings->preconnection_blob;
+    }
+#endif
+
     /* Order support */
 #ifdef LEGACY_RDPSETTINGS
     bitmap_cache = rdp_settings->bitmap_cache;

--- a/src/protocols/rdp/rdp_settings.h
+++ b/src/protocols/rdp/rdp_settings.h
@@ -266,6 +266,20 @@ typedef struct guac_rdp_settings {
      */
     int menu_animations_enabled;
 
+    /**
+     * The preconnection ID to send within the preconnection PDU when
+     * initiating an RDP connection, if any. If no preconnection ID is
+     * specified, this will be -1.
+     */
+    int preconnection_id;
+
+    /**
+     * The preconnection BLOB (PCB) to send to the RDP server prior to full RDP
+     * connection negotiation. This value is used by Hyper-V to select the
+     * destination VM.
+     */
+    char* preconnection_blob;
+
 } guac_rdp_settings;
 
 /**


### PR DESCRIPTION
Connecting to the display of a Hyper-V VM requires submitting arbitrary data along RDP's "preconnection PDU" - a means of selecting the so-called "RDP source". This is documented as the "Session Selection Extension" for the RDP protocol: https://msdn.microsoft.com/en-us/library/cc242375.aspx

The "Session Selection Extension" defines two possible fields for selecting the RDP session: a positive integer ID, and an arbitrary string known as the "preconnection BLOB". In practice, the preconnection BLOB is used to select a Hyper-V VM while the ID is left unset.

As far as the RDP protocol is concerned, the true meaning of the ID and BLOB are left opaque. It is up to the server to interpret them.