### PR TITLE
GUAC-1410: Add ja-jp keymap

### DIFF
--- a/src/protocols/rdp/Makefile.am
+++ b/src/protocols/rdp/Makefile.am
@@ -213,7 +213,8 @@ rdp_keymaps =                   \
     keymaps/en_us_qwerty.keymap \
     keymaps/fr_fr_azerty.keymap \
     keymaps/it_it_qwerty.keymap \
-    keymaps/sv_se_qwerty.keymap
+    keymaps/sv_se_qwerty.keymap \
+    keymaps/ja_jp_qwerty.keymap
 
 _generated_keymaps.c: $(rdp_keymaps)
 	keymaps/generate.pl $(rdp_keymaps)

--- a/src/protocols/rdp/keymaps/ja_jp_qwerty.keymap
+++ b/src/protocols/rdp/keymaps/ja_jp_qwerty.keymap
@@ -1,0 +1,39 @@
+#
+# Copyright (C) 2013 Glyptodon LLC
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+parent  "base"
+name    "ja-jp-qwerty"
+freerdp "KBD_JAPANESE"
+
+map -shift      0x02..0x0D 0x7D ~ "1234567890-^\"
+map -shift      0x10..0x1B      ~ "qwertyuiop@["
+map -shift      0x1E..0x28 0x2B ~ "asdfghjkl;:]"
+map -shift      0x2C..0x35 0x73 ~ "zxcvbnm,./\"
+
+map +shift      0x02..0x0A 0x0C 0x0D 0x7D ~ "!"#$%&'()=~|"
+map +shift      0x10..0x1B      ~ "QWERTYUIOP`{"
+map +shift      0x1E..0x28 0x2B ~ "ASDFGHJKL+*}"
+map +shift      0x2C..0x35 0x73 ~ "ZXCVBNM<>?_"
+
+map -shift      0x29            ~ 0xFF28
+map -shift      0x29            ~ 0xFF2A
+map +shift      0x29            ~ 0xFF29


### PR DESCRIPTION
Although GUAC-439 claims Guacamole's keyboard input is not dependent on keyboard layout, the half is the case.

On the client side the keycode in the keyboard event propagated from the browser is independent from the keyboard layout, but on the server side it needs to be converted to the appropriate virtual keycode designated by the keyboard layout with which the operating system hosting the desktop is configured.

