### PR TITLE
GUAC-1410: Fix keymap ordering in Makefile.am.

### DIFF
--- a/src/protocols/rdp/Makefile.am
+++ b/src/protocols/rdp/Makefile.am
@@ -213,8 +213,8 @@ rdp_keymaps =                   \
     keymaps/en_us_qwerty.keymap \
     keymaps/fr_fr_azerty.keymap \
     keymaps/it_it_qwerty.keymap \
-    keymaps/sv_se_qwerty.keymap \
-    keymaps/ja_jp_qwerty.keymap
+    keymaps/ja_jp_qwerty.keymap \
+    keymaps/sv_se_qwerty.keymap
 
 _generated_keymaps.c: $(rdp_keymaps)
 	keymaps/generate.pl $(rdp_keymaps)


### PR DESCRIPTION
This change simply restores the lexicographical ordering of the keymap files within `Makefile.am`.