### PR TITLE
GUAC-1389: Add missing includes for guacd's connection.c

### DIFF
--- a/src/guacd/connection.c
+++ b/src/guacd/connection.c
@@ -43,6 +43,8 @@
 #endif
 
 #include <errno.h>
+#include <stdlib.h>
+#include <string.h>
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <sys/wait.h>


### PR DESCRIPTION
We're using `malloc()` / `free()` (from "stdlib.h") and `strerror()` (from "string.h"), and yet those includes are missing.