### PR TITLE
GUAC-1389: Fix user validity race.

### DIFF
--- a/src/common/guac_cursor.c
+++ b/src/common/guac_cursor.c
@@ -362,12 +362,3 @@ void guac_common_cursor_set_blank(guac_common_cursor* cursor) {
 
 }
 
-void guac_common_cursor_remove_user(guac_common_cursor* cursor,
-        guac_user* user) {
-
-    /* Disassociate from given user */
-    if (cursor->user == user)
-        cursor->user = NULL;
-
-}
-

--- a/src/common/guac_cursor.h
+++ b/src/common/guac_cursor.h
@@ -252,19 +252,4 @@ void guac_common_cursor_set_ibar(guac_common_cursor* cursor);
  */
 void guac_common_cursor_set_blank(guac_common_cursor* cursor);
 
-/**
- * Removes the given user, such that future synchronization will not occur.
- * This is necessary when a user leaves the connection. If a user leaves the
- * connection and this is not called, the corresponding guac_user and socket
- * may cease to be valid, and future synchronization attempts will segfault.
- *
- * @param cursor
- *     The cursor to remove the user from.
- *
- * @param user
- *     The user to remove.
- */
-void guac_common_cursor_remove_user(guac_common_cursor* cursor,
-        guac_user* user);
-
 #endif

--- a/src/libguac/client.c
+++ b/src/libguac/client.c
@@ -637,6 +637,43 @@ void* guac_client_for_owner(guac_client* client, guac_user_callback* callback,
 
 }
 
+void* guac_client_for_user(guac_client* client, guac_user* user,
+        guac_user_callback* callback, void* data) {
+
+    guac_user* current;
+
+    int user_valid = 0;
+    void* retval;
+
+    pthread_rwlock_rdlock(&(client->__users_lock));
+
+    /* Loop through all users, searching for a pointer to the given user */
+    current = client->__users;
+    while (current != NULL) {
+
+        /* If the user's pointer exists in the list, they are indeed valid */
+        if (current == user) {
+            user_valid = 1;
+            break;
+        }
+
+        current = current->__next;
+    }
+
+    /* Use NULL if user does not actually exist */
+    if (!user_valid)
+        user = NULL;
+
+    /* Invoke callback with requested user (if they exist) */
+    retval = callback(user, data);
+
+    pthread_rwlock_unlock(&(client->__users_lock));
+
+    /* Return value from callback */
+    return retval;
+
+}
+
 int guac_client_end_frame(guac_client* client) {
 
     /* Update and send timestamp */

--- a/src/libguac/guacamole/client.h
+++ b/src/libguac/guacamole/client.h
@@ -457,14 +457,10 @@ void guac_client_foreach_user(guac_client* client,
         guac_user_callback* callback, void* data);
 
 /**
- * Retrieves the connected user that is marked as the owner. The owner of a
- * connection is the user that established the initial connection that created
- * the connection (the first user to connect and join).
- *
- * Calls the given function on with the currently-connected user that is marked
- * as the owner. The owner of a connection is the user that established the
+ * Calls the given function with the currently-connected user that is marked as
+ * the owner. The owner of a connection is the user that established the
  * initial connection that created the connection (the first user to connect
- * and join). The function will be given a reference to a guac_user and the
+ * and join). The function will be given a reference to the guac_user and the
  * specified arbitrary data. If the owner has since left the connection, the
  * function will instead be invoked with NULL as the guac_user. The value
  * returned by the callback will be returned by this function.
@@ -480,11 +476,57 @@ void guac_client_foreach_user(guac_client* client,
  * @param client
  *     The client to retrieve the owner from.
  *
+ * @param callback
+ *     The callback to invoke on the user marked as the owner of the
+ *     connection.. NULL will be passed to this callback instead if there is no
+ *     owner.
+ *
+ * @param data
+ *     Arbitrary data to pass to the given callback.
+ *
  * @return
  *     The value returned by the callback.
  */
 void* guac_client_for_owner(guac_client* client, guac_user_callback* callback,
         void* data);
+
+/**
+ * Calls the given function with the given user ONLY if they are currently
+ * connected. The function will be given a reference to the guac_user and the
+ * specified arbitrary data. If the provided user doesn't exist or has since
+ * left the connection, the function will instead be invoked with NULL as the
+ * guac_user. The value returned by the callback will be returned by this
+ * function.
+ *
+ * This function is reentrant, but the user list MUST NOT be manipulated
+ * within the same thread as a callback to this function.
+ *
+ * Because this function depends on a consistent list of connected users, this
+ * function MUST NOT be invoked within the same thread as a "leave" or "join"
+ * handler. Doing so results in undefined behavior, including possible
+ * segfaults.
+ *
+ * @param client
+ *     The client that the given user is expected to be associated with.
+ *
+ * @param user
+ *     The user to provide to the given callback if valid. The pointer need not
+ *     even point to properly allocated memory; the user will only be passed to
+ *     the callback function if they are valid, and the provided user pointer
+ *     will not be dereferenced during this process.
+ *
+ * @param callback
+ *     The callback to invoke on the given user if they are valid. NULL will be
+ *     passed to this callback instead if the user is not valid.
+ *
+ * @param data
+ *     Arbitrary data to pass to the given callback.
+ *
+ * @return
+ *     The value returned by the callback.
+ */
+void* guac_client_for_user(guac_client* client, guac_user* user,
+        guac_user_callback* callback, void* data);
 
 /**
  * Marks the end of the current frame by sending a "sync" instruction to

--- a/src/libguac/guacamole/client.h
+++ b/src/libguac/guacamole/client.h
@@ -478,7 +478,7 @@ void guac_client_foreach_user(guac_client* client,
  *
  * @param callback
  *     The callback to invoke on the user marked as the owner of the
- *     connection.. NULL will be passed to this callback instead if there is no
+ *     connection. NULL will be passed to this callback instead if there is no
  *     owner.
  *
  * @param data

--- a/src/protocols/vnc/user.c
+++ b/src/protocols/vnc/user.c
@@ -100,12 +100,3 @@ int guac_vnc_user_join_handler(guac_user* user, int argc, char** argv) {
 
 }
 
-int guac_vnc_user_leave_handler(guac_user* user) {
-
-    guac_vnc_client* vnc_client = (guac_vnc_client*) user->client->data;
-
-    guac_common_cursor_remove_user(vnc_client->display->cursor, user);
-
-    return 0;
-}
-

--- a/src/protocols/vnc/user.h
+++ b/src/protocols/vnc/user.h
@@ -32,10 +32,5 @@
  */
 guac_user_join_handler guac_vnc_user_join_handler;
 
-/**
- * Handler for leaving users.
- */
-guac_user_leave_handler guac_vnc_user_leave_handler;
-
 #endif
 


### PR DESCRIPTION
If a user leaves a connection, any existing reference to their `guac_user` structure may suddenly become invalid. While `guac_common_cursor` made an effort to deal with this by updating the user pointer when a user leaves, the race still exists (the window is just smaller).

This change adds a new `guac_client_for_user()` function which allows a callback to be invoked for the given user if and only if the user pointer is actually valid. If they don't exist, `NULL` is passed to the callback instead.