### PR TITLE
GUAC-1389: Stretch RDP and VNC frames until client has caught up.

### DIFF
--- a/src/protocols/rdp/client.h
+++ b/src/protocols/rdp/client.h
@@ -37,7 +37,7 @@
  * milliseconds. If the server is silent for at least this amount of time, the
  * frame will be considered finished.
  */
-#define GUAC_RDP_FRAME_TIMEOUT 10
+#define GUAC_RDP_FRAME_TIMEOUT 0
 
 /**
  * The amount of time to wait for a new message from the RDP server when

--- a/src/protocols/vnc/client.h
+++ b/src/protocols/vnc/client.h
@@ -36,7 +36,7 @@
  * milliseconds. If the server is silent for at least this amount of time, the
  * frame will be considered finished.
  */
-#define GUAC_VNC_FRAME_TIMEOUT 10
+#define GUAC_VNC_FRAME_TIMEOUT 0
 
 /**
  * The amount of time to wait for a new message from the VNC server when


### PR DESCRIPTION
This change also sets the frame timeouts to zero, relying instead on the automatic duration adjustment.