### PR TITLE
GUAC-1164: Add parameter for automatically reconnecting when display changes

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -437,7 +437,6 @@ if test "x$with_rdp" != "xno"
 then
     have_winpr=yes
     have_freerdp=yes
-    have_disp=yes
     legacy_freerdp_extensions=no
     rdpsettings_interface=unknown
     rdpsettings_audioplayback=yes
@@ -554,8 +553,7 @@ then
                      [AC_DEFINE([HAVE_FREERDP_DISPLAY_UPDATE_SUPPORT],,
                                 [Whether FreeRDP supports the display update channel])]
                      [AC_CHECK_MEMBERS([rdpSettings.SupportDisplayControl],,,
-                                       [[#include <freerdp/freerdp.h>]])],
-                     have_disp=no,
+                                       [[#include <freerdp/freerdp.h>]])],,
                      [#include <winpr/wtypes.h>
                       #include <winpr/collections.h>])
 fi
@@ -869,7 +867,6 @@ then
 fi
 
 AM_CONDITIONAL([LEGACY_FREERDP_EXTENSIONS], [test "x${legacy_freerdp_extensions}" = "xyes"])
-AM_CONDITIONAL([ENABLE_DISPLAY_UPDATE], [test "x${have_disp}" = "xyes"])
 AM_CONDITIONAL([ENABLE_WINPR], [test "x${have_winpr}"   = "xyes"])
 AM_CONDITIONAL([ENABLE_RDP],   [test "x${have_freerdp}" = "xyes"])
 

--- a/src/common/guac_cursor.c
+++ b/src/common/guac_cursor.c
@@ -29,6 +29,7 @@
 
 #include <cairo/cairo.h>
 #include <guacamole/client.h>
+#include <guacamole/layer.h>
 #include <guacamole/protocol.h>
 #include <guacamole/socket.h>
 #include <guacamole/user.h>
@@ -70,13 +71,20 @@ guac_common_cursor* guac_common_cursor_alloc(guac_client* client) {
 
 void guac_common_cursor_free(guac_common_cursor* cursor) {
 
+    guac_client* client = cursor->client;
+    guac_layer* layer = cursor->layer;
+    cairo_surface_t* surface = cursor->surface;
+
     /* Free image buffer and surface */
     free(cursor->image_buffer);
-    if (cursor->surface != NULL)
-        cairo_surface_destroy(cursor->surface);
+    if (surface != NULL)
+        cairo_surface_destroy(surface);
+
+    /* Destroy layer within remotely-connected client */
+    guac_protocol_send_dispose(client->socket, layer);
 
     /* Return layer to pool */
-    guac_client_free_layer(cursor->client, cursor->layer);
+    guac_client_free_layer(client, layer);
 
     free(cursor);
 

--- a/src/common/guac_display.c
+++ b/src/common/guac_display.c
@@ -84,6 +84,9 @@ static void guac_common_display_free_layers(guac_common_display_layer* layers,
         /* Free surface */
         guac_common_surface_free(current->surface);
 
+        /* Destroy layer within remotely-connected client */
+        guac_protocol_send_dispose(client->socket, layer);
+
         /* Free layer or buffer depending on index */
         if (layer->index < 0)
             guac_client_free_buffer(client, layer);

--- a/src/protocols/rdp/Makefile.am
+++ b/src/protocols/rdp/Makefile.am
@@ -33,6 +33,7 @@ libguac_client_rdp_la_SOURCES = \
     rdp_bitmap.c                \
     rdp_cliprdr.c               \
     rdp_color.c                 \
+    rdp_disp.c                  \
     rdp_fs.c                    \
     rdp_gdi.c                   \
     rdp_glyph.c                 \
@@ -87,6 +88,7 @@ noinst_HEADERS =                             \
     rdp_bitmap.h                             \
     rdp_cliprdr.h                            \
     rdp_color.h                              \
+    rdp_disp.h                               \
     rdp_fs.h                                 \
     rdp_gdi.h                                \
     rdp_glyph.h                              \
@@ -108,12 +110,6 @@ libguac_client_rdp_la_SOURCES += compat/winpr-stream.c
 guacsvc_sources += compat/winpr-stream.c
 guacsnd_sources += compat/winpr-stream.c
 guacdr_sources  += compat/winpr-stream.c
-endif
-
-# Add display update channel support, if supported by FreeRDP
-if ENABLE_DISPLAY_UPDATE
-noinst_HEADERS += rdp_disp.h
-libguac_client_rdp_la_SOURCES += rdp_disp.c
 endif
 
 #

--- a/src/protocols/rdp/client.c
+++ b/src/protocols/rdp/client.c
@@ -24,6 +24,7 @@
 
 #include "client.h"
 #include "rdp.h"
+#include "rdp_disp.h"
 #include "rdp_keymap.h"
 #include "user.h"
 
@@ -31,10 +32,6 @@
 #include <guac_sftp.h>
 #include <guac_ssh.h>
 #include <guac_ssh_user.h>
-#endif
-
-#ifdef HAVE_FREERDP_DISPLAY_UPDATE_SUPPORT
-#include "rdp_disp.h"
 #endif
 
 #include <freerdp/cache/cache.h>
@@ -66,10 +63,11 @@ int guac_client_init(guac_client* client, int argc, char** argv) {
     guac_rdp_client* rdp_client = calloc(1, sizeof(guac_rdp_client));
     client->data = rdp_client;
 
-    /* Init clipboard and shared mouse */
+    /* Init clipboard */
     rdp_client->clipboard = guac_common_clipboard_alloc(GUAC_RDP_CLIPBOARD_MAX_LENGTH);
-    rdp_client->requested_clipboard_format = CB_FORMAT_TEXT;
-    rdp_client->available_svc = guac_common_list_alloc();
+
+    /* Init display update module */
+    rdp_client->disp = guac_rdp_disp_alloc();
 
     /* Recursive attribute for locks */
     pthread_mutexattr_init(&(rdp_client->attributes));
@@ -98,54 +96,15 @@ int guac_rdp_client_free_handler(guac_client* client) {
     /* Wait for client thread */
     pthread_join(rdp_client->client_thread, NULL);
 
-    freerdp* rdp_inst = rdp_client->rdp_inst;
-    if (rdp_inst != NULL) {
-        rdpChannels* channels = rdp_inst->context->channels;
-
-        /* Clean up RDP client */
-        freerdp_channels_close(channels, rdp_inst);
-        freerdp_channels_free(channels);
-        freerdp_disconnect(rdp_inst);
-        freerdp_clrconv_free(((rdp_freerdp_context*) rdp_inst->context)->clrconv);
-        cache_free(rdp_inst->context->cache);
-        freerdp_free(rdp_inst);
-    }
-
-    /* Clean up filesystem, if allocated */
-    if (rdp_client->filesystem != NULL)
-        guac_rdp_fs_free(rdp_client->filesystem);
-
-#ifdef ENABLE_COMMON_SSH
-    /* Free SFTP filesystem, if loaded */
-    if (rdp_client->sftp_filesystem)
-        guac_common_ssh_destroy_sftp_filesystem(rdp_client->sftp_filesystem);
-
-    /* Free SFTP session */
-    if (rdp_client->sftp_session)
-        guac_common_ssh_destroy_session(rdp_client->sftp_session);
-
-    /* Free SFTP user */
-    if (rdp_client->sftp_user)
-        guac_common_ssh_destroy_user(rdp_client->sftp_user);
-
-    guac_common_ssh_uninit();
-#endif
-
-#ifdef HAVE_FREERDP_DISPLAY_UPDATE_SUPPORT
-    /* Free display update module */
-    guac_rdp_disp_free(rdp_client->disp);
-#endif
-
-    /* Free SVC list */
-    guac_common_list_free(rdp_client->available_svc);
-
     /* Free parsed settings */
     if (rdp_client->settings != NULL)
         guac_rdp_settings_free(rdp_client->settings);
 
+    /* Free display update module */
+    guac_rdp_disp_free(rdp_client->disp);
+
     /* Free client data */
     guac_common_clipboard_free(rdp_client->clipboard);
-    guac_common_display_free(rdp_client->display);
     free(rdp_client);
 
     return 0;

--- a/src/protocols/rdp/rdp.c
+++ b/src/protocols/rdp/rdp.c
@@ -170,27 +170,30 @@ static int __guac_receive_channel_data(freerdp* rdp_inst, int channelId,
 static void guac_rdp_channel_connected(rdpContext* context,
         ChannelConnectedEventArgs* e) {
 
+    guac_client* client = ((rdp_freerdp_context*) context)->client;
+    guac_rdp_client* rdp_client = (guac_rdp_client*) client->data;
+    guac_rdp_settings* settings = rdp_client->settings;
+
+    if (settings->resize_method == GUAC_RESIZE_DISPLAY_UPDATE) {
 #ifdef HAVE_RDPSETTINGS_SUPPORTDISPLAYCONTROL
-    /* Store reference to the display update plugin once it's connected */
-    if (strcmp(e->name, DISP_DVC_CHANNEL_NAME) == 0) {
+        /* Store reference to the display update plugin once it's connected */
+        if (strcmp(e->name, DISP_DVC_CHANNEL_NAME) == 0) {
 
-        DispClientContext* disp = (DispClientContext*) e->pInterface;
+            DispClientContext* disp = (DispClientContext*) e->pInterface;
 
-        guac_client* client = ((rdp_freerdp_context*) context)->client;
-        guac_rdp_client* rdp_client = (guac_rdp_client*) client->data;
+            /* Init module with current display size */
+            guac_rdp_disp_set_size(rdp_client->disp, rdp_client->settings,
+                    context->instance, guac_rdp_get_width(context->instance),
+                    guac_rdp_get_height(context->instance));
 
-        /* Init module with current display size */
-        guac_rdp_disp_set_size(rdp_client->disp, rdp_client->settings,
-                context->instance, guac_rdp_get_width(context->instance),
-                guac_rdp_get_height(context->instance));
+            /* Store connected channel */
+            guac_rdp_disp_connect(rdp_client->disp, disp);
+            guac_client_log(client, GUAC_LOG_DEBUG,
+                    "Display update channel connected.");
 
-        /* Store connected channel */
-        guac_rdp_disp_connect(rdp_client->disp, disp);
-        guac_client_log(client, GUAC_LOG_DEBUG,
-                "Display update channel connected.");
-
-    }
+        }
 #endif
+    }
 
 }
 #endif

--- a/src/protocols/rdp/rdp.c
+++ b/src/protocols/rdp/rdp.c
@@ -691,6 +691,25 @@ static int rdp_guac_client_wait_for_messages(guac_client* client,
 
 }
 
+/**
+ * Connects to an RDP server as described by the guac_rdp_settings structure
+ * associated with the given client, allocating and freeing all objects
+ * directly related to the RDP connection. It is expected that all objects
+ * which are independent of FreeRDP's state (the clipboard, display update
+ * management, etc.) will already be allocated and associated with the
+ * guac_rdp_client associated with the given guac_client. This function blocks
+ * for the duration of the RDP session, returning only after the session has
+ * completely disconnected.
+ *
+ * @param client
+ *     The guac_client associated with the RDP settings describing the
+ *     connection that should be established.
+ *
+ * @return
+ *     Zero if the connection successfully terminated and a reconnect is
+ *     desired, non-zero if an error occurs or the connection was disconnected
+ *     and a reconnect is NOT desired.
+ */
 static int guac_rdp_handle_connection(guac_client* client) {
 
     guac_rdp_client* rdp_client = (guac_rdp_client*) client->data;

--- a/src/protocols/rdp/rdp.h
+++ b/src/protocols/rdp/rdp.h
@@ -29,6 +29,7 @@
 #include "guac_display.h"
 #include "guac_surface.h"
 #include "guac_list.h"
+#include "rdp_disp.h"
 #include "rdp_fs.h"
 #include "rdp_keymap.h"
 #include "rdp_settings.h"
@@ -42,10 +43,6 @@
 #include "guac_sftp.h"
 #include "guac_ssh.h"
 #include "guac_ssh_user.h"
-#endif
-
-#ifdef HAVE_FREERDP_DISPLAY_UPDATE_SUPPORT
-#include "rdp_disp.h"
 #endif
 
 #include <pthread.h>
@@ -148,12 +145,10 @@ typedef struct guac_rdp_client {
     guac_common_ssh_sftp_filesystem* sftp_filesystem;
 #endif
 
-#ifdef HAVE_FREERDP_DISPLAY_UPDATE_SUPPORT
     /**
      * Display size update module.
      */
     guac_rdp_disp* disp;
-#endif
 
     /**
      * List of all available static virtual channels.
@@ -161,7 +156,9 @@ typedef struct guac_rdp_client {
     guac_common_list* available_svc;
 
     /**
-     * Lock which is locked and unlocked for each RDP message.
+     * Lock which is locked and unlocked for each RDP message, and for each
+     * part of the RDP client instance which may be dynamically freed and
+     * reallocated during reconnection.
      */
     pthread_mutex_t rdp_lock;
 

--- a/src/protocols/rdp/rdp_disp.c
+++ b/src/protocols/rdp/rdp_disp.c
@@ -169,37 +169,37 @@ void guac_rdp_disp_update_size(guac_rdp_disp* disp,
 
     disp->last_request = now;
 
-    if (1) {
+    if (settings->resize_method == GUAC_RESIZE_RECONNECT) {
+
         /* Update settings with new dimensions */
         settings->width = width;
         settings->height = height;
 
         /* Signal reconnect */
         disp->reconnect_needed = 1;
-#ifdef HAVE_FREERDP_DISPLAY_UPDATE_SUPPORT
-        disp->disp = NULL;
-#endif
-        return;
+
     }
 
+    else if (settings->resize_method == GUAC_RESIZE_DISPLAY_UPDATE) {
 #ifdef HAVE_FREERDP_DISPLAY_UPDATE_SUPPORT
-    DISPLAY_CONTROL_MONITOR_LAYOUT monitors[1] = {{
-        .Flags  = 0x1, /* DISPLAYCONTROL_MONITOR_PRIMARY */
-        .Left = 0,
-        .Top = 0,
-        .Width  = width,
-        .Height = height,
-        .PhysicalWidth = 0,
-        .PhysicalHeight = 0,
-        .Orientation = 0,
-        .DesktopScaleFactor = 0,
-        .DeviceScaleFactor = 0
-    }};
+        DISPLAY_CONTROL_MONITOR_LAYOUT monitors[1] = {{
+            .Flags  = 0x1, /* DISPLAYCONTROL_MONITOR_PRIMARY */
+            .Left = 0,
+            .Top = 0,
+            .Width  = width,
+            .Height = height,
+            .PhysicalWidth = 0,
+            .PhysicalHeight = 0,
+            .Orientation = 0,
+            .DesktopScaleFactor = 0,
+            .DeviceScaleFactor = 0
+        }};
 
-    /* Send display update notification if display channel is connected */
-    if (disp->disp != NULL)
-        disp->disp->SendMonitorLayout(disp->disp, 1, monitors);
+        /* Send display update notification if display channel is connected */
+        if (disp->disp != NULL)
+            disp->disp->SendMonitorLayout(disp->disp, 1, monitors);
 #endif
+    }
 
 }
 

--- a/src/protocols/rdp/rdp_disp.c
+++ b/src/protocols/rdp/rdp_disp.c
@@ -72,9 +72,11 @@ void guac_rdp_disp_load_plugin(rdpContext* context) {
 
 }
 
+#ifdef HAVE_FREERDP_DISPLAY_UPDATE_SUPPORT
 void guac_rdp_disp_connect(guac_rdp_disp* guac_disp, DispClientContext* disp) {
     guac_disp->disp = disp;
 }
+#endif
 
 /**
  * Fits a given dimension within the allowed bounds for Display Update

--- a/src/protocols/rdp/rdp_disp.c
+++ b/src/protocols/rdp/rdp_disp.c
@@ -209,5 +209,6 @@ int guac_rdp_disp_reconnect_needed(guac_rdp_disp* disp) {
 
 void guac_rdp_disp_reconnect_complete(guac_rdp_disp* disp) {
     disp->reconnect_needed = 0;
+    disp->last_request = guac_timestamp_current();
 }
 

--- a/src/protocols/rdp/rdp_disp.c
+++ b/src/protocols/rdp/rdp_disp.c
@@ -44,7 +44,7 @@ guac_rdp_disp* guac_rdp_disp_alloc() {
 #endif
 
     /* No requests have been made */
-    disp->last_request = 0;
+    disp->last_request = guac_timestamp_current();
     disp->requested_width  = 0;
     disp->requested_height = 0;
     disp->reconnect_needed = 0;
@@ -157,8 +157,7 @@ void guac_rdp_disp_update_size(guac_rdp_disp* disp,
     guac_timestamp now = guac_timestamp_current();
 
     /* Limit display update frequency */
-    if (disp->last_request != 0
-            && now - disp->last_request <= GUAC_RDP_DISP_UPDATE_INTERVAL)
+    if (now - disp->last_request <= GUAC_RDP_DISP_UPDATE_INTERVAL)
         return;
 
     /* Do NOT send requests unless the size will change */

--- a/src/protocols/rdp/rdp_disp.c
+++ b/src/protocols/rdp/rdp_disp.c
@@ -27,9 +27,12 @@
 #include "rdp_settings.h"
 
 #include <freerdp/freerdp.h>
-#include <freerdp/client/disp.h>
 #include <guacamole/client.h>
 #include <guacamole/timestamp.h>
+
+#ifdef HAVE_FREERDP_CLIENT_DISP_H
+#include <freerdp/client/disp.h>
+#endif
 
 guac_rdp_disp* guac_rdp_disp_alloc() {
 

--- a/src/protocols/rdp/rdp_disp.c
+++ b/src/protocols/rdp/rdp_disp.c
@@ -38,8 +38,10 @@ guac_rdp_disp* guac_rdp_disp_alloc() {
 
     guac_rdp_disp* disp = malloc(sizeof(guac_rdp_disp));
 
+#ifdef HAVE_FREERDP_DISPLAY_UPDATE_SUPPORT
     /* Not yet connected */
     disp->disp = NULL;
+#endif
 
     /* No requests have been made */
     disp->last_request = 0;
@@ -174,7 +176,9 @@ void guac_rdp_disp_update_size(guac_rdp_disp* disp,
 
         /* Signal reconnect */
         disp->reconnect_needed = 1;
+#ifdef HAVE_FREERDP_DISPLAY_UPDATE_SUPPORT
         disp->disp = NULL;
+#endif
         return;
     }
 

--- a/src/protocols/rdp/rdp_disp.h
+++ b/src/protocols/rdp/rdp_disp.h
@@ -25,8 +25,11 @@
 
 #include "rdp_settings.h"
 
-#include <freerdp/client/disp.h>
 #include <freerdp/freerdp.h>
+
+#ifdef HAVE_FREERDP_CLIENT_DISP_H
+#include <freerdp/client/disp.h>
+#endif
 
 /**
  * The minimum value for width or height, in pixels.
@@ -49,10 +52,12 @@
  */
 typedef struct guac_rdp_disp {
 
+#ifdef HAVE_FREERDP_DISPLAY_UPDATE_SUPPORT
     /**
      * Display control interface.
      */
     DispClientContext* disp;
+#endif
 
     /**
      * The timestamp of the last display update request, or 0 if no request

--- a/src/protocols/rdp/rdp_disp.h
+++ b/src/protocols/rdp/rdp_disp.h
@@ -107,6 +107,7 @@ void guac_rdp_disp_free(guac_rdp_disp* disp);
  */
 void guac_rdp_disp_load_plugin(rdpContext* context);
 
+#ifdef HAVE_FREERDP_DISPLAY_UPDATE_SUPPORT
 /**
  * Stores the given DispClientContext within the given guac_rdp_disp, such that
  * display updates can be properly sent. Until this is called, changes to the
@@ -118,6 +119,7 @@ void guac_rdp_disp_load_plugin(rdpContext* context);
  *             display update channel.
  */
 void guac_rdp_disp_connect(guac_rdp_disp* guac_disp, DispClientContext* disp);
+#endif
 
 /**
  * Requests a display size update, which may then be sent immediately to the

--- a/src/protocols/rdp/rdp_settings.c
+++ b/src/protocols/rdp/rdp_settings.c
@@ -92,6 +92,7 @@ const char* GUAC_RDP_CLIENT_ARGS[] = {
     "recording-path",
     "recording-name",
     "create-recording-path",
+    "resize-method",
 
     NULL
 };
@@ -359,6 +360,12 @@ enum RDP_ARGS_IDX {
     IDX_RECORDING_PATH,
     IDX_RECORDING_NAME,
     IDX_CREATE_RECORDING_PATH,
+
+    /**
+     * The method to use to apply screen size changes requested by the user.
+     * Valid values are blank, "display-update", and "reconnect".
+     */
+    IDX_RESIZE_METHOD,
 
     RDP_ARGS_COUNT
 };
@@ -695,6 +702,31 @@ guac_rdp_settings* guac_rdp_parse_args(guac_user* user,
     settings->create_recording_path =
         guac_user_parse_args_boolean(user, GUAC_RDP_CLIENT_ARGS, argv,
                 IDX_CREATE_RECORDING_PATH, 0);
+
+    /* No resize method */
+    if (strcmp(argv[IDX_RESIZE_METHOD], "") == 0) {
+        guac_user_log(user, GUAC_LOG_INFO, "Resize method: none");
+        settings->resize_method = GUAC_RESIZE_NONE;
+    }
+
+    /* Resize method: "reconnect" */
+    else if (strcmp(argv[IDX_RESIZE_METHOD], "reconnect") == 0) {
+        guac_user_log(user, GUAC_LOG_INFO, "Resize method: reconnect");
+        settings->resize_method = GUAC_RESIZE_RECONNECT;
+    }
+
+    /* Resize method: "display-update" */
+    else if (strcmp(argv[IDX_RESIZE_METHOD], "display-update") == 0) {
+        guac_user_log(user, GUAC_LOG_INFO, "Resize method: display-update");
+        settings->resize_method = GUAC_RESIZE_DISPLAY_UPDATE;
+    }
+
+    /* Default to no resize method if invalid */
+    else {
+        guac_user_log(user, GUAC_LOG_INFO, "Resize method \"%s\" invalid. ",
+                "Defaulting to no resize method.", argv[IDX_RESIZE_METHOD]);
+        settings->resize_method = GUAC_RESIZE_NONE;
+    }
 
     /* Success */
     return settings;

--- a/src/protocols/rdp/rdp_settings.h
+++ b/src/protocols/rdp/rdp_settings.h
@@ -89,6 +89,32 @@ typedef enum guac_rdp_security {
 } guac_rdp_security;
 
 /**
+ * All supported combinations screen resize methods.
+ */
+typedef enum guac_rdp_resize_method {
+
+    /**
+     * Dynamic resizing of the display will not be attempted.
+     */
+    GUAC_RESIZE_NONE,
+
+    /**
+     * Dynamic resizing will be attempted through sending requests along the
+     * Display Update channel. This will only work with recent versions of
+     * Windows and relatively-recent versions of FreeRDP.
+     */
+    GUAC_RESIZE_DISPLAY_UPDATE,
+
+    /**
+     * Guacamole will automatically disconnect and reconnect to the RDP server
+     * whenever the screen size changes, requesting the new size during
+     * reconnect.
+     */
+    GUAC_RESIZE_RECONNECT
+
+} guac_rdp_resize_method;
+
+/**
  * All settings supported by the Guacamole RDP client.
  */
 typedef struct guac_rdp_settings {
@@ -349,6 +375,11 @@ typedef struct guac_rdp_settings {
      * does not already exist.
      */
     int create_recording_path;
+
+    /**
+     * The method to apply when the user's display changes size.
+     */
+    guac_rdp_resize_method resize_method;
 
 } guac_rdp_settings;
 


### PR DESCRIPTION
This change adds a new "reconnect-method" parameter for RDP which accepts two values: "reconnect", which disconnects and reconnects the RDP session when the screen size changes, and "display-update", which uses the "Display Update" channel available with RDP 8.1+. If the parameter is left blank, screen size changes are simply ignored.