### PR TITLE
GUACD-1513: systemd init script

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -41,6 +41,9 @@ SUBDIRS =       \
     src/common  \
     tests
 
+DISTCHECK_CONFIGURE_FLAGS = \
+  --with-systemdsystemunitdir=$$dc_install_base/$(systemdsystemunitdir)
+
 if ENABLE_COMMON_SSH
 SUBDIRS += src/common-ssh
 endif

--- a/configure.ac
+++ b/configure.ac
@@ -138,6 +138,24 @@ AC_ARG_WITH(init_dir,
 AM_CONDITIONAL([ENABLE_INIT], [test "x${init_dir}" != "x"])
 AC_SUBST(init_dir)
 
+# systemd directory
+PKG_PROG_PKG_CONFIG
+AC_ARG_WITH([systemdsystemunitdir],
+     [AS_HELP_STRING([--with-systemdsystemunitdir=DIR], [Directory for systemd service files])],,
+     [with_systemdsystemunitdir=auto])
+AS_IF([test "x$with_systemdsystemunitdir" = "xyes" -o "x$with_systemdsystemunitdir" = "xauto"], [
+     def_systemdsystemunitdir=$($PKG_CONFIG --variable=systemdsystemunitdir systemd)
+
+     AS_IF([test "x$def_systemdsystemunitdir" = "x"],
+          [AS_IF([test "x$with_systemdsystemunitdir" = "xyes"],
+                 [AC_MSG_ERROR([systemd support requested but pkg-config unable to query systemd package])])
+                 with_systemdsystemunitdir=no],
+          [with_systemdsystemunitdir="$def_systemdsystemunitdir"])])
+
+AS_IF([test "x$with_systemdsystemunitdir" != "xno"],
+      [AC_SUBST([systemdsystemunitdir], [$with_systemdsystemunitdir])])
+AM_CONDITIONAL([HAVE_SYSTEMD], [test "x$with_systemdsystemunitdir" != "xno"])
+
 # guacd config file
 AC_ARG_WITH(guacd_conf,
             [AS_HELP_STRING([--with-guacd-conf=<path>],
@@ -1127,6 +1145,7 @@ $PACKAGE_NAME version $PACKAGE_VERSION
       guacenc .... ${build_guacenc}
 
    Init scripts: ${build_init}
+   Systemd scripts: ${with_systemdsystemunitdir}
 
 Type \"make\" to compile $PACKAGE_NAME.
 "

--- a/src/guacd/Makefile.am
+++ b/src/guacd/Makefile.am
@@ -65,11 +65,12 @@ guacd_LDFLAGS =    \
     @SSL_LIBS@
 
 EXTRA_DIST =         \
+    systemd/guacd.service.in \
     init.d/guacd.in  \
     man/guacd.8      \
     man/guacd.conf.5
 
-CLEANFILES = $(init_SCRIPTS)
+CLEANFILES = $(init_SCRIPTS) $(systemdsystemunit_DATA)
 
 # SSL support
 if ENABLE_SSL
@@ -87,3 +88,13 @@ init.d/guacd: init.d/guacd.in
 	chmod +x init.d/guacd
 endif
 
+if HAVE_SYSTEMD
+SCRIPT_IN_FILES = systemd/guacd.service
+
+systemd/guacd.service: systemd/guacd.service.in
+	sed -e 's,[@]sbindir[@],$(sbindir),g' < systemd/guacd.service.in > systemd/guacd.service
+	chmod 644 systemd/guacd.service
+
+systemdsystemunit_DATA = systemd/guacd.service
+
+endif

--- a/src/guacd/systemd/guacd.service.in
+++ b/src/guacd/systemd/guacd.service.in
@@ -1,0 +1,15 @@
+[Unit]
+Description=Guacamole proxy daemon
+Documentation=man:guacd(8)
+After=network.target
+
+[Service]
+ExecStart=@sbindir@/guacd -f
+Restart=on-failure
+# the following 2 allow to set the user/group for guacd process
+#User=guacd
+#Group=guacd
+
+[Install]
+WantedBy=multi-user.target
+


### PR DESCRIPTION
This adds support for native systemd init files instead of using the traditional initd init scripts. A new configuration option is been added to the configure.am.