### PR TITLE
Include FFMPEG/Guacenc

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,6 +45,7 @@ ENV \
         pango                         \
         pulseaudio-libs               \
         terminus-fonts                \
+        ffmpeg                        \
         uuid"                         \
     BUILD_DEPENDENCIES="              \
         autoconf                      \
@@ -62,11 +63,15 @@ ENV \
         make                          \
         pango-devel                   \
         pulseaudio-libs-devel         \
+        ffmpeg                        \
+        ffmpeg-devel                  \
         uuid-devel"
 
 # Bring environment up-to-date and install guacamole-server dependencies
 RUN yum -y update                        && \
     yum -y install epel-release          && \
+    rpm --import http://li.nux.ro/download/nux/RPM-GPG-KEY-nux.ro && \
+    rpm -Uvh http://li.nux.ro/download/nux/dextop/el7/x86_64/nux-dextop-release-0-1.el7.nux.noarch.rpm && \
     yum -y install $RUNTIME_DEPENDENCIES && \
     yum clean all
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,6 +46,7 @@ ENV \
         pulseaudio-libs               \
         terminus-fonts                \
         ffmpeg                        \
+        ffmpeg-libs                   \
         uuid"                         \
     BUILD_DEPENDENCIES="              \
         autoconf                      \
@@ -63,7 +64,6 @@ ENV \
         make                          \
         pango-devel                   \
         pulseaudio-libs-devel         \
-        ffmpeg                        \
         ffmpeg-devel                  \
         uuid-devel"
 


### PR DESCRIPTION
The current docker image `guacd` does not include the `guacenc` utility.  Installing `ffmpeg` allows this to build and be included.

I imagine there are licensing issues that might prevent this pull from being accepted, but wanted to pass along how we're using it just in case it is useful.  Is there a better way to ensure `guacenc` is included in the build, and or is there a way we can get this into the official image?