### PR TITLE
GUACAMOLE-424: Fix a crash if vnc password does not match remote password

### DIFF
--- a/src/protocols/vnc/user.c
+++ b/src/protocols/vnc/user.c
@@ -112,6 +112,10 @@ int guac_vnc_user_leave_handler(guac_user* user) {
 
     guac_vnc_client* vnc_client = (guac_vnc_client*) user->client->data;
 
+    if (vnc_client->display == NULL) {
+        return 1;
+    }
+
     /* Update shared cursor state */
     guac_common_cursor_remove_user(vnc_client->display->cursor, user);
 


### PR DESCRIPTION
Introduce an easy patch which prevents a null pointer dereference when client can't connect to the remote server over VNC protocol due to VNC password mismatch. Actually there are other places where it is possible to hit the same problem, but an improvements for them may be introduced in future PRs.