### PR TITLE
GLEN-112: Add support for modification of terminal palette.

### DIFF
--- a/src/terminal/display.c
+++ b/src/terminal/display.c
@@ -121,7 +121,7 @@ int __guac_terminal_set_colors(guac_terminal_display* display,
     if (attributes->bold && !attributes->half_bright
             && foreground->palette_index >= GUAC_TERMINAL_FIRST_DARK
             && foreground->palette_index <= GUAC_TERMINAL_LAST_DARK) {
-        foreground = &guac_terminal_palette[foreground->palette_index
+        foreground = &display->palette[foreground->palette_index
             + GUAC_TERMINAL_INTENSE_OFFSET];
     }
 
@@ -322,6 +322,44 @@ void guac_terminal_display_free(guac_terminal_display* display) {
 
     /* Free display */
     free(display);
+
+}
+
+void guac_terminal_display_reset_palette(guac_terminal_display* display) {
+
+    /* Reinitialize palette with default values */
+    memcpy(display->palette, GUAC_TERMINAL_INITIAL_PALETTE,
+            sizeof(GUAC_TERMINAL_INITIAL_PALETTE));
+
+}
+
+int guac_terminal_display_assign_color(guac_terminal_display* display,
+        int index, const guac_terminal_color* color) {
+
+    /* Assignment fails if out-of-bounds */
+    if (index < 0 || index > 255)
+        return 1;
+
+    /* Copy color components */
+    display->palette[index].red   = color->red;
+    display->palette[index].green = color->green;
+    display->palette[index].blue  = color->blue;
+
+    /* Color successfully stored */
+    return 0;
+
+}
+
+int guac_terminal_display_lookup_color(guac_terminal_display* display,
+        int index, guac_terminal_color* color) {
+
+    /* Lookup fails if out-of-bounds */
+    if (index < 0 || index > 255)
+        return 1;
+
+    /* Copy color definition */
+    *color = display->palette[index];
+    return 0;
 
 }
 

--- a/src/terminal/palette.c
+++ b/src/terminal/palette.c
@@ -20,7 +20,7 @@
 #include "config.h"
 #include "terminal/palette.h"
 
-const guac_terminal_color guac_terminal_palette[256] = {
+const guac_terminal_color GUAC_TERMINAL_INITIAL_PALETTE[256] = {
 
     /* Normal colors */
     {0, 0x00, 0x00, 0x00}, /* Black   */

--- a/src/terminal/terminal.c
+++ b/src/terminal/terminal.c
@@ -178,6 +178,9 @@ void guac_terminal_reset(guac_terminal* term) {
     term->tab_interval = 8;
     memset(term->custom_tabs, 0, sizeof(term->custom_tabs));
 
+    /* Reset display palette */
+    guac_terminal_display_reset_palette(term->display);
+
     /* Clear terminal */
     for (row=0; row<term->term_height; row++)
         guac_terminal_set_columns(term, row, 0, term->term_width, &(term->default_char));
@@ -296,8 +299,8 @@ guac_terminal* guac_terminal_create(guac_client* client,
     guac_terminal_char default_char = {
         .value = 0,
         .attributes = {
-            .foreground  = guac_terminal_palette[default_foreground],
-            .background  = guac_terminal_palette[default_background],
+            .foreground  = GUAC_TERMINAL_INITIAL_PALETTE[default_foreground],
+            .background  = GUAC_TERMINAL_INITIAL_PALETTE[default_background],
             .bold        = false,
             .half_bright = false,
             .reverse     = false,

--- a/src/terminal/terminal/display.h
+++ b/src/terminal/terminal/display.h
@@ -32,6 +32,7 @@
 #include <pango/pangocairo.h>
 
 #include <stdbool.h>
+#include <stdint.h>
 
 /**
  * The maximum width of any character, in columns.
@@ -92,7 +93,8 @@ typedef struct guac_terminal_operation {
 } guac_terminal_operation;
 
 /**
- * Set of all pending operations for the currently-visible screen area.
+ * Set of all pending operations for the currently-visible screen area, and the
+ * contextual information necessary to interpret and render those changes.
  */
 typedef struct guac_terminal_display {
 
@@ -130,6 +132,11 @@ typedef struct guac_terminal_display {
      * The height of each character, in pixels.
      */
     int char_height;
+
+    /**
+     * The current palette.
+     */
+    guac_terminal_color palette[256];
 
     /**
      * Default foreground color for all glyphs.
@@ -214,6 +221,55 @@ guac_terminal_display* guac_terminal_display_alloc(guac_client* client,
  * Frees the given display.
  */
 void guac_terminal_display_free(guac_terminal_display* display);
+
+/**
+ * Resets the palette of the given display to the initial, default color
+ * values, as defined by GUAC_TERMINAL_INITIAL_PALETTE.
+ *
+ * @param display
+ *     The display to reset.
+ */
+void guac_terminal_display_reset_palette(guac_terminal_display* display);
+
+/**
+ * Replaces the color in the palette at the given index with the given color.
+ * If the index is invalid, the assignment is ignored.
+ *
+ * @param display
+ *     The display whose palette is being changed.
+ *
+ * @param index
+ *     The index of the palette entry to change.
+ *
+ * @param color
+ *     The color to assign to the palette entry having the given index.
+ *
+ * @returns
+ *     Zero if the assignment was successful, non-zero if the assignment
+ *     failed.
+ */
+int guac_terminal_display_assign_color(guac_terminal_display* display,
+        int index, const guac_terminal_color* color);
+
+/**
+ * Retrieves the color within the palette at the given index, if such a color
+ * exists. If the index is invalid, no color is retrieved.
+ *
+ * @param display
+ *     The display whose palette contains the color to be retrieved.
+ *
+ * @param index
+ *     The index of the palette entry to retrieve.
+ *
+ * @param color
+ *     A pointer to a guac_terminal_color structure which should receive the
+ *     color retrieved from the palette.
+ *
+ * @returns
+ *     Zero if the color was successfully retrieved, non-zero otherwise.
+ */
+int guac_terminal_display_lookup_color(guac_terminal_display* display,
+        int index, guac_terminal_color* color);
 
 /**
  * Copies the given range of columns to a new location, offset from

--- a/src/terminal/terminal/palette.h
+++ b/src/terminal/terminal/palette.h
@@ -185,9 +185,11 @@ int guac_terminal_colorcmp(const guac_terminal_color* a,
         const guac_terminal_color* b);
 
 /**
- * The terminal color palette.
+ * The initial state of the terminal color palette. The color palette used by
+ * the terminal may modified after the terminal is created through console
+ * codes.
  */
-extern const guac_terminal_color guac_terminal_palette[256];
+extern const guac_terminal_color GUAC_TERMINAL_INITIAL_PALETTE[256];
 
 #endif
 

--- a/src/terminal/terminal/terminal.h
+++ b/src/terminal/terminal/terminal.h
@@ -314,7 +314,8 @@ struct guac_terminal {
 
     /**
      * The difference between the currently-rendered screen and the current
-     * state of the terminal.
+     * state of the terminal, and the contextual information necessary to
+     * interpret and render those differences.
      */
     guac_terminal_display* display;
 

--- a/src/terminal/terminal_handlers.c
+++ b/src/terminal/terminal_handlers.c
@@ -490,6 +490,9 @@ static int guac_terminal_parse_xterm256_rgb(int argc, const int* argv,
  * Parses an xterm SGR sequence specifying the index of a color within the
  * 256-color palette.
  *
+ * @param terminal
+ *     The terminal associated with the palette.
+ *
  * @param argc
  *     The number of arguments within the argv array.
  *
@@ -505,20 +508,15 @@ static int guac_terminal_parse_xterm256_rgb(int argc, const int* argv,
  *     The number of arguments parsed, or zero if the palette index is
  *     absent.
  */
-static int guac_terminal_parse_xterm256_index(int argc, const int* argv,
-        guac_terminal_color* color) {
+static int guac_terminal_parse_xterm256_index(guac_terminal* terminal,
+        int argc, const int* argv, guac_terminal_color* color) {
 
     /* 256-color palette entries require only one argument */
     if (argc < 1)
         return 0;
 
-    /* Ignore if palette index is out of bounds */
-    int index = argv[0];
-    if (index < 0 || index > 255)
-        return 1;
-
     /* Copy palette entry */
-    *color = guac_terminal_palette[index];
+    guac_terminal_display_lookup_color(terminal->display, argv[0], color);
 
     /* Done */
     return 1;
@@ -530,6 +528,10 @@ static int guac_terminal_parse_xterm256_index(int argc, const int* argv,
  * 256-color palette, or specfying the RGB values of a color. The number of
  * arguments required by these sequences varies. If a 256-color sequence is
  * recognized, the number of arguments parsed is returned.
+ *
+ * @param terminal
+ *     The terminal whose palette state should be used when parsing the xterm
+ *     256-color SGR sequence.
  *
  * @param argc
  *     The number of arguments within the argv array.
@@ -549,8 +551,8 @@ static int guac_terminal_parse_xterm256_index(int argc, const int* argv,
  *     The number of arguments parsed, or zero if argv does not point to
  *     the first element of an xterm 256-color SGR sequence.
  */
-static int guac_terminal_parse_xterm256(int argc, const int* argv,
-        guac_terminal_color* color) {
+static int guac_terminal_parse_xterm256(guac_terminal* terminal,
+        int argc, const int* argv, guac_terminal_color* color) {
 
     /* All 256-color codes must have at least a type */
     if (argc < 1)
@@ -565,7 +567,7 @@ static int guac_terminal_parse_xterm256(int argc, const int* argv,
 
         /* Palette index */
         case 5:
-            return guac_terminal_parse_xterm256_index(
+            return guac_terminal_parse_xterm256_index(terminal,
                     argc - 1, &argv[1], color) + 1;
 
     }
@@ -926,8 +928,9 @@ int guac_terminal_csi(guac_terminal* term, unsigned char c) {
 
                     /* Foreground */
                     else if (value >= 30 && value <= 37)
-                        term->current_attributes.foreground =
-                            guac_terminal_palette[value - 30];
+                        guac_terminal_display_lookup_color(term->display,
+                                value - 30,
+                                &term->current_attributes.foreground);
 
                     /* Underscore on, default foreground OR 256-color
                      * foreground */
@@ -935,7 +938,8 @@ int guac_terminal_csi(guac_terminal* term, unsigned char c) {
 
                         /* Attempt to set foreground with 256-color entry */
                         int xterm256_length =
-                            guac_terminal_parse_xterm256(argc - i - 1, &argv[i + 1],
+                            guac_terminal_parse_xterm256(term,
+                                    argc - i - 1, &argv[i + 1],
                                     &term->current_attributes.foreground);
 
                         /* If valid 256-color entry, foreground has been set */
@@ -961,13 +965,15 @@ int guac_terminal_csi(guac_terminal* term, unsigned char c) {
 
                     /* Background */
                     else if (value >= 40 && value <= 47)
-                        term->current_attributes.background =
-                            guac_terminal_palette[value - 40];
+                        guac_terminal_display_lookup_color(term->display,
+                                value - 40,
+                                &term->current_attributes.background);
 
                     /* 256-color background */
                     else if (value == 48)
-                        i += guac_terminal_parse_xterm256(argc - i - 1, &argv[i + 1],
-                                    &term->current_attributes.background);
+                        i += guac_terminal_parse_xterm256(term,
+                                argc - i - 1, &argv[i + 1],
+                                &term->current_attributes.background);
 
                     /* Reset background */
                     else if (value == 49)
@@ -976,15 +982,15 @@ int guac_terminal_csi(guac_terminal* term, unsigned char c) {
 
                     /* Intense foreground */
                     else if (value >= 90 && value <= 97)
-                        term->current_attributes.foreground =
-                            guac_terminal_palette[value - 90
-                                + GUAC_TERMINAL_FIRST_INTENSE];
+                        guac_terminal_display_lookup_color(term->display,
+                                value - 90 + GUAC_TERMINAL_FIRST_INTENSE,
+                                &term->current_attributes.foreground);
 
                     /* Intense background */
                     else if (value >= 100 && value <= 107)
-                        term->current_attributes.background =
-                            guac_terminal_palette[value - 100
-                                + GUAC_TERMINAL_FIRST_INTENSE];
+                        guac_terminal_display_lookup_color(term->display,
+                                value - 100 + GUAC_TERMINAL_FIRST_INTENSE,
+                                &term->current_attributes.background);
 
                 }
 


### PR DESCRIPTION
PR #145 added support for console codes that modify the terminal, but was missing backported code from the other half of GUACAMOLE-279 which added core support for terminal mutability. This PR backports those changes, as well.