### PR TITLE
GLEN-123: Add support for changing SSH/telnet window title

### DIFF
--- a/src/protocols/rdp/rdp.c
+++ b/src/protocols/rdp/rdp.c
@@ -711,9 +711,6 @@ static int guac_rdp_handle_connection(guac_client* client) {
     rdp_client->keyboard = guac_rdp_keyboard_alloc(client,
             settings->server_layout);
 
-    /* Send connection name */
-    guac_protocol_send_name(client->socket, settings->hostname);
-
     /* Set default pointer */
     guac_common_cursor_set_pointer(rdp_client->display->cursor);
 

--- a/src/protocols/vnc/vnc.c
+++ b/src/protocols/vnc/vnc.c
@@ -308,9 +308,6 @@ void* guac_vnc_client_thread(void* data) {
                 settings->create_recording_path);
     }
 
-    /* Send name */
-    guac_protocol_send_name(client->socket, rfb_client->desktopName);
-
     /* Create display */
     vnc_client->display = guac_common_display_alloc(client,
             rfb_client->width, rfb_client->height);

--- a/src/terminal/terminal/terminal_handlers.h
+++ b/src/terminal/terminal/terminal_handlers.h
@@ -139,6 +139,19 @@ int guac_terminal_open_pipe_stream(guac_terminal* term, unsigned char c);
 int guac_terminal_close_pipe_stream(guac_terminal* term, unsigned char c);
 
 /**
+ * Parses the remainder of an OSC sequence setting the window title. The
+ * window title is everything after the window title sequence begins, up to
+ * the end of the OSC sequence itself.
+ *
+ * @param term
+ *     The terminal that received the given character of data.
+ *
+ * @param c
+ *     The character that was received by the given terminal.
+ */
+int guac_terminal_window_title(guac_terminal* term, unsigned char c);
+
+/**
  * Parses the remainder of xterm's OSC sequence for redefining the terminal
  * emulator's palette.
  *

--- a/src/terminal/terminal_handlers.c
+++ b/src/terminal/terminal_handlers.c
@@ -1181,6 +1181,36 @@ int guac_terminal_close_pipe_stream(guac_terminal* term, unsigned char c) {
 
 }
 
+int guac_terminal_window_title(guac_terminal* term, unsigned char c) {
+
+    static int position = 0;
+    static char title[4096];
+
+    guac_socket* socket = term->client->socket;
+
+    /* Stop on ECMA-48 ST (String Terminator */
+    if (c == 0x9C || c == 0x5C || c == 0x07) {
+
+        /* Terminate and reset stored title */
+        title[position] = '\0';
+        position = 0;
+
+        /* Send title as connection name */
+        guac_protocol_send_name(socket, title);
+        guac_socket_flush(socket);
+
+        term->char_handler = guac_terminal_echo;
+
+    }
+
+    /* Store all other characters within title, space permitting */
+    else if (position < sizeof(title) - 1)
+        title[position++] = (char) c;
+
+    return 0;
+
+}
+
 int guac_terminal_xterm_palette(guac_terminal* term, unsigned char c) {
 
     /**
@@ -1288,6 +1318,10 @@ int guac_terminal_osc(guac_terminal* term, unsigned char c) {
         /* Close pipe stream OSC */
         else if (operation == 482203)
             term->char_handler = guac_terminal_close_pipe_stream;
+
+        /* Set window title OSC */
+        else if (operation == 0 || operation == 2)
+            term->char_handler = guac_terminal_window_title;
 
         /* xterm 256-color palette redefinition */
         else if (operation == 4)


### PR DESCRIPTION
These changes, combining upstream [GUACAMOLE-265](https://issues.apache.org/jira/browse/GUACAMOLE-265) and [GUACAMOLE-502](https://issues.apache.org/jira/browse/GUACAMOLE-502), are the server-side changes required by glyptodon/guacamole-client#365.

[GUACAMOLE-265](https://issues.apache.org/jira/browse/GUACAMOLE-265) adds the base support for sending the "name" instruction in response to the terminal code used to change window title, while [GUACAMOLE-502](https://issues.apache.org/jira/browse/GUACAMOLE-502) fixes the behavioral regression in the handling of connection name/title for VNC and RDP which resulted from those changes. Together, these changes add the necessary support in a stable manner.