### PR TITLE
GLEN-121: Address potential segfault during SSH disconnect.

### DIFF
--- a/src/protocols/ssh/client.c
+++ b/src/protocols/ssh/client.c
@@ -70,8 +70,12 @@ int guac_ssh_client_free_handler(guac_client* client) {
 
     /* Free terminal (which may still be using term_channel) */
     if (ssh_client->term != NULL) {
-        guac_terminal_free(ssh_client->term);
+        /* Stop the terminal to unblock any pending reads/writes */
+        guac_terminal_stop(ssh_client->term);
+
+        /* Wait ssh_client_thread to finish before freeing the terminal */
         pthread_join(ssh_client->client_thread, NULL);
+        guac_terminal_free(ssh_client->term);
     }
 
     /* Free terminal channel now that the terminal is finished */

--- a/src/protocols/ssh/ssh.c
+++ b/src/protocols/ssh/ssh.c
@@ -162,8 +162,14 @@ void* ssh_input_thread(void* data) {
         pthread_mutex_lock(&(ssh_client->term_channel_lock));
         libssh2_channel_write(ssh_client->term_channel, buffer, bytes_read);
         pthread_mutex_unlock(&(ssh_client->term_channel_lock));
+
+        /* Make sure ssh_input_thread can be terminated anyway */
+        if (client->state == GUAC_CLIENT_STOPPING)
+            break;
     }
 
+    /* Stop the client so that ssh_client_thread can be terminated */
+    guac_client_stop(client);
     return NULL;
 
 }
@@ -332,6 +338,12 @@ void* ssh_client_thread(void* data) {
 
         /* Stop reading at EOF */
         if (libssh2_channel_eof(ssh_client->term_channel)) {
+            pthread_mutex_unlock(&(ssh_client->term_channel_lock));
+            break;
+        }
+
+        /* Client is stopping, break the loop */
+        if (client->state == GUAC_CLIENT_STOPPING) {
             pthread_mutex_unlock(&(ssh_client->term_channel_lock));
             break;
         }

--- a/src/terminal/terminal.c
+++ b/src/terminal/terminal.c
@@ -410,11 +410,23 @@ guac_terminal* guac_terminal_create(guac_client* client,
 
 }
 
+void guac_terminal_stop(guac_terminal* term) {
+
+    /* Close input pipe and set fds to invalid */
+    if (term->stdin_pipe_fd[1] != -1) {
+        close(term->stdin_pipe_fd[1]);
+        term->stdin_pipe_fd[1] = -1;
+    }
+    if (term->stdin_pipe_fd[0] != -1) {
+        close(term->stdin_pipe_fd[0]);
+        term->stdin_pipe_fd[0] = -1;
+    }
+}
+
 void guac_terminal_free(guac_terminal* term) {
 
     /* Close user input pipe */
-    close(term->stdin_pipe_fd[1]);
-    close(term->stdin_pipe_fd[0]);
+    guac_terminal_stop(term);
 
     /* Wait for render thread to finish */
     pthread_join(term->thread, NULL);

--- a/src/terminal/terminal/terminal.h
+++ b/src/terminal/terminal/terminal.h
@@ -492,6 +492,15 @@ int guac_terminal_render_frame(guac_terminal* terminal);
 int guac_terminal_read_stdin(guac_terminal* terminal, char* c, int size);
 
 /**
+ * Manually stop the terminal to forcibly unblock any pending reads/writes,
+ * e.g. forcing guac_terminal_read_stdin() to return and cease all terminal I/O.
+ *
+ * @param term
+ *     The terminal to stop.
+ */
+void guac_terminal_stop(guac_terminal* term);
+
+/**
  * Notifies the terminal that an event has occurred and the terminal should
  * flush itself when reasonable.
  *


### PR DESCRIPTION
From upstream [GUACAMOLE-384](https://issues.apache.org/jira/browse/GUACAMOLE-384):

> Looks like the terminal is being freed during normal connection cleanup, but prior to the SSH client thread finishing. Depending on timing, attempts to write to the terminal by the SSH client thread segfault since the terminal was already freed.
> 
> This needs to be fixed, but will not affect the stability of connections in practice, as the segfault is occurring during normal disconnect.
> 
> ...
> 
> Yes, that's what I meant by the comment above.
> 
> The thread in this case is the SSH client thread, created to handle the underlying SSH connection after the first user joins:
> 
> https://github.com/apache/incubator-guacamole-server/blob/d35cc7a83e8dfdaa44cbd3b02c70e9407197155a/src/protocols/ssh/user.c#L56-L70
> 
> If you look at the free handler for the `guac_client` created for the SSH connection, you can see that the terminal is freed prior to waiting for the thread to finish:
> 
> https://github.com/apache/incubator-guacamole-server/blob/d35cc7a83e8dfdaa44cbd3b02c70e9407197155a/src/protocols/ssh/client.c#L73-L74
> 
> This creates a race condition which could result in data being written by the client thread to the freed terminal, causing a segfault. The fix may be as simple as switching the order of those lines, but such a change will need to be carefully verified. The SSH client thread depends on certain conditions for the thread to terminate. If switching those lines results in a chance of those conditions not occurring, then we'll be replacing a low-impact segfault with high-impact deadlock.
> 
> The SSH client and input threads should probably take the client running state into account (the value manipulated by `guac_client_stop()`), to ensure they will terminate regardless of the current state of the terminal or underlying SSH connection.
> 
