### PR TITLE
GLEN-122: Backport fixes for buffer handling and threadsafety

### DIFF
--- a/src/guacd/move-fd.c
+++ b/src/guacd/move-fd.c
@@ -44,7 +44,7 @@ int guacd_send_fd(int sock, int fd) {
     message.msg_iovlen = 1;
 
     /* Assign ancillary data buffer */
-    char buffer[CMSG_SPACE(sizeof(fd))];
+    char buffer[CMSG_SPACE(sizeof(fd))] = {0};
     message.msg_control = buffer;
     message.msg_controllen = sizeof(buffer);
 

--- a/src/libguac/socket-fd.c
+++ b/src/libguac/socket-fd.c
@@ -98,10 +98,10 @@ ssize_t guac_socket_fd_write(guac_socket* socket,
 
 #ifdef __MINGW32__
         /* MINGW32 WINSOCK only works with send() */
-        retval = send(data->fd, buf, count, 0);
+        retval = send(data->fd, buffer, count, 0);
 #else
         /* Use write() for all other platforms */
-        retval = write(data->fd, buf, count);
+        retval = write(data->fd, buffer, count);
 #endif
 
         /* Record errors in guac_error */
@@ -111,7 +111,7 @@ ssize_t guac_socket_fd_write(guac_socket* socket,
             return retval;
         }
 
-        /* Advance buffer as data retval */
+        /* Advance buffer to next chunk */
         buffer += retval;
         count  -= retval;
 

--- a/src/libguac/socket-tee.c
+++ b/src/libguac/socket-tee.c
@@ -135,8 +135,9 @@ static void __guac_socket_tee_lock_handler(guac_socket* socket) {
 
     guac_socket_tee_data* data = (guac_socket_tee_data*) socket->data;
 
-    /* Delegate lock to wrapped socket */
+    /* Delegate lock to wrapped sockets */
     guac_socket_instruction_begin(data->primary);
+    guac_socket_instruction_begin(data->secondary);
 
 }
 
@@ -151,7 +152,8 @@ static void __guac_socket_tee_unlock_handler(guac_socket* socket) {
 
     guac_socket_tee_data* data = (guac_socket_tee_data*) socket->data;
 
-    /* Delegate unlock to wrapped socket */
+    /* Delegate unlock to wrapped sockets */
+    guac_socket_instruction_end(data->secondary);
     guac_socket_instruction_end(data->primary);
 
 }


### PR DESCRIPTION
Relevant issues:

* [GUACAMOLE-324](https://issues.apache.org/jira/browse/GUACAMOLE-324) - "Incorrect buffer used in socket write"
* [GUACAMOLE-411](https://issues.apache.org/jira/browse/GUACAMOLE-411) - "guacd_send_fd call's sendmsg with uninitialized buffer"
* [GUACAMOLE-489](https://issues.apache.org/jira/browse/GUACAMOLE-489) - "Secondary socket of "tee" socket is not threadsafe"