### PR TITLE
GLEN-139: Add Glyptodon Enterprise version number suffix.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1111,7 +1111,10 @@ AC_CONFIG_FILES([Makefile
                  src/libguac/Makefile
                  src/libguacd/Makefile
                  src/guacd/Makefile
+                 src/guacd/man/guacd.8
+                 src/guacd/man/guacd.conf.5
                  src/guacenc/Makefile
+                 src/guacenc/man/guacenc.1
                  src/pulse/Makefile
                  src/protocols/rdp/Makefile
                  src/protocols/ssh/Makefile

--- a/configure.ac
+++ b/configure.ac
@@ -18,7 +18,7 @@
 #
 
 AC_PREREQ([2.61])
-AC_INIT([guacamole-server], [0.9.12-incubating])
+AC_INIT([guacamole-server], [0.9.12-GLEN-1.8])
 AM_INIT_AUTOMAKE([-Wall -Werror foreign subdir-objects])
 AM_SILENT_RULES([yes])
 

--- a/src/guacd/.gitignore
+++ b/src/guacd/.gitignore
@@ -6,6 +6,10 @@ init.d/guacd
 guacd
 guacd.exe
 
+# Documentation (built from .in files)
+man/guacd.8
+man/guacd.conf.5
+
 # Object code
 *.o
 *.so

--- a/src/guacd/Makefile.am
+++ b/src/guacd/Makefile.am
@@ -61,10 +61,10 @@ guacd_LDFLAGS =    \
     @PTHREAD_LIBS@ \
     @SSL_LIBS@
 
-EXTRA_DIST =         \
-    init.d/guacd.in  \
-    man/guacd.8      \
-    man/guacd.conf.5
+EXTRA_DIST =            \
+    init.d/guacd.in     \
+    man/guacd.8.in      \
+    man/guacd.conf.5.in
 
 CLEANFILES = $(init_SCRIPTS)
 

--- a/src/guacd/man/guacd.8.in
+++ b/src/guacd/man/guacd.8.in
@@ -16,7 +16,7 @@
 .\" specific language governing permissions and limitations
 .\" under the License.
 .\"
-.TH guacd 8 "9 Jan 2017" "version 0.9.11-incubating" "Guacamole"
+.TH guacd 8 "1 Jun 2017" "version @PACKAGE_VERSION@" "Apache Guacamole"
 .
 .SH NAME
 guacd \- Guacamole proxy daemon
@@ -112,6 +112,3 @@ this option is not given, communication with guacd must be unencrypted.
 .
 .SH SEE ALSO
 .BR guacd.conf (5)
-.
-.SH AUTHOR
-Written by Michael Jumper <mike.jumper@guac-dev.org>

--- a/src/guacd/man/guacd.conf.5.in
+++ b/src/guacd/man/guacd.conf.5.in
@@ -16,7 +16,7 @@
 .\" specific language governing permissions and limitations
 .\" under the License.
 .\"
-.TH guacd.conf 5 "9 Jan 2017" "version 0.9.11-incubating" "Guacamole"
+.TH guacd.conf 5 "1 Jun 2017" "version @PACKAGE_VERSION@" "Apache Guacamole"
 .
 .SH NAME
 /etc/guacamole/guacd.conf \- Configuration file for guacd
@@ -175,6 +175,3 @@ server_certificate = /etc/ssl/certs/guacd.crt
 server_key = /etc/ssl/private/guacd.key
 .RE
 .fi
-.
-.SH AUTHOR
-Written by Michael Jumper <mike.jumper@guac-dev.org>

--- a/src/guacenc/.gitignore
+++ b/src/guacenc/.gitignore
@@ -3,3 +3,6 @@
 guacenc
 guacenc.exe
 
+# Documentation (built from .in files)
+man/guacenc.1
+

--- a/src/guacenc/Makefile.am
+++ b/src/guacenc/Makefile.am
@@ -96,6 +96,6 @@ guacenc_LDFLAGS =  \
     @SWSCALE_LIBS@ \
     @WEBP_LIBS@
 
-EXTRA_DIST =      \
-    man/guacenc.1
+EXTRA_DIST =         \
+    man/guacenc.1.in
 

--- a/src/guacenc/man/guacenc.1.in
+++ b/src/guacenc/man/guacenc.1.in
@@ -16,7 +16,7 @@
 .\" specific language governing permissions and limitations
 .\" under the License.
 .\"
-.TH guacenc 1 "9 Jan 2017" "version 0.9.11-incubating" "Guacamole"
+.TH guacenc 1 "1 Jun 2017" "version @PACKAGE_VERSION@" "Apache Guacamole"
 .
 .SH NAME
 guacenc \- Guacamole video encoder
@@ -75,6 +75,3 @@ Overrides the default behavior of
 .B guacenc
 such that input files will be encoded even if they appear to be recordings of
 in-progress Guacamole sessions.
-.
-.SH AUTHOR
-Written by Michael Jumper <mike.jumper@guac-dev.org>


### PR DESCRIPTION
Note that this change also includes a commit which cherry-picks the following upstream commits:

* 76a6e41 GUACAMOLE-423: Automatically populate package version within manpages.
* 139251e GUACAMOLE-492: Remove guaclog binary erroneously added to source tree.

This has been done so that the version numbers within the documentation (man pages) are also updated.