### PR TITLE
GLEN-161: Allow SSH locale to be explicitly set

### DIFF
--- a/src/protocols/ssh/settings.c
+++ b/src/protocols/ssh/settings.c
@@ -55,6 +55,7 @@ const char* GUAC_SSH_CLIENT_ARGS[] = {
     "backspace",
     "terminal-type",
     "scrollback",
+    "locale",
     NULL
 };
 
@@ -194,6 +195,14 @@ enum SSH_ARGS_IDX {
      */
     IDX_SCROLLBACK,
 
+    /**
+     * The locale that should be forwarded to the remote system via the LANG
+     * environment variable. By default, no locale is forwarded. This setting
+     * will only have an effect if the SSH server allows the LANG environment
+     * variable to be set.
+     */
+    IDX_LOCALE,
+
     SSH_ARGS_COUNT
 };
 
@@ -328,6 +337,11 @@ guac_ssh_settings* guac_ssh_parse_args(guac_user* user,
         guac_user_parse_args_string(user, GUAC_SSH_CLIENT_ARGS, argv,
                 IDX_TERMINAL_TYPE, "linux");
 
+    /* Read locale */
+    settings->locale =
+        guac_user_parse_args_string(user, GUAC_SSH_CLIENT_ARGS, argv,
+                IDX_LOCALE, NULL);
+
     /* Parsing was successful */
     return settings;
 
@@ -362,6 +376,9 @@ void guac_ssh_settings_free(guac_ssh_settings* settings) {
 
     /* Free terminal emulator type. */
     free(settings->terminal_type);
+
+    /* Free locale */
+    free(settings->locale);
 
     /* Free overall structure */
     free(settings);

--- a/src/protocols/ssh/settings.h
+++ b/src/protocols/ssh/settings.h
@@ -211,6 +211,12 @@ typedef struct guac_ssh_settings {
      */
     char* terminal_type;
 
+    /**
+     * The locale that should be forwarded to the remote system via the LANG
+     * environment variable.
+     */
+    char* locale;
+
 } guac_ssh_settings;
 
 /**

--- a/src/protocols/ssh/ssh.c
+++ b/src/protocols/ssh/ssh.c
@@ -314,6 +314,16 @@ void* ssh_client_thread(void* data) {
         return NULL;
     }
 
+    /* Forward specified locale */
+    if (settings->locale != NULL) {
+        if (libssh2_channel_setenv(ssh_client->term_channel, "LANG",
+                    settings->locale)) {
+            guac_client_log(client, GUAC_LOG_WARNING,
+                    "Unable to forward locale: SSH server refused to set "
+                    "\"LANG\" environment variable.");
+        }
+    }
+
     /* If a command is specified, run that instead of a shell */
     if (settings->command != NULL) {
         if (libssh2_channel_exec(ssh_client->term_channel, settings->command)) {


### PR DESCRIPTION
These changes depend on #171. The merge base will need to be updated to `glyptodon/1.x` once #171 is merged.