### PR TITLE
GLEN-162: Add support for timezone redirection

### DIFF
--- a/src/protocols/rdp/rdp.c
+++ b/src/protocols/rdp/rdp.c
@@ -715,7 +715,7 @@ static int guac_rdp_handle_connection(guac_client* client) {
     guac_common_cursor_set_pointer(rdp_client->display->cursor);
 
     /* Push desired settings to FreeRDP */
-    guac_rdp_push_settings(settings, rdp_inst);
+    guac_rdp_push_settings(client, settings, rdp_inst);
 
     /* Connect to RDP server */
     if (!freerdp_connect(rdp_inst)) {

--- a/src/protocols/rdp/rdp_settings.h
+++ b/src/protocols/rdp/rdp_settings.h
@@ -323,6 +323,11 @@ typedef struct guac_rdp_settings {
      */
     char* preconnection_blob;
 
+    /**
+     * The timezone to pass through to the RDP connection.
+     */
+    char* timezone;
+
 #ifdef ENABLE_COMMON_SSH
     /**
      * Whether SFTP should be enabled for the VNC connection.
@@ -447,13 +452,17 @@ extern const char* GUAC_RDP_CLIENT_ARGS[];
 /**
  * Save all given settings to the given freerdp instance.
  *
+ * @param client
+ *     The guac_client object providing the settings.
+ *
  * @param guac_settings
  *     The guac_rdp_settings object to save.
  *
  * @param rdp
  *     The RDP instance to save settings to.
  */
-void guac_rdp_push_settings(guac_rdp_settings* guac_settings, freerdp* rdp);
+void guac_rdp_push_settings(guac_client* client,
+        guac_rdp_settings* guac_settings, freerdp* rdp);
 
 /**
  * Returns the width of the RDP session display.

--- a/src/protocols/ssh/settings.c
+++ b/src/protocols/ssh/settings.c
@@ -56,6 +56,7 @@ const char* GUAC_SSH_CLIENT_ARGS[] = {
     "terminal-type",
     "scrollback",
     "locale",
+    "timezone",
     NULL
 };
 
@@ -202,6 +203,16 @@ enum SSH_ARGS_IDX {
      * variable to be set.
      */
     IDX_LOCALE,
+     
+    /**
+     * The timezone that is to be passed to the remote system, via the
+     * TZ environment variable.  By default, no timezone is forwarded
+     * and the timezone of the remote system will be used.  This
+     * setting will only work if the SSH server allows the TZ variable
+     * to be set.  Timezones should be in standard IANA format, see:
+     * https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
+     */
+    IDX_TIMEZONE,
 
     SSH_ARGS_COUNT
 };
@@ -342,6 +353,11 @@ guac_ssh_settings* guac_ssh_parse_args(guac_user* user,
         guac_user_parse_args_string(user, GUAC_SSH_CLIENT_ARGS, argv,
                 IDX_LOCALE, NULL);
 
+    /* Read the client timezone. */
+    settings->timezone =
+        guac_user_parse_args_string(user, GUAC_SSH_CLIENT_ARGS, argv,
+                IDX_TIMEZONE, NULL);
+
     /* Parsing was successful */
     return settings;
 
@@ -379,6 +395,9 @@ void guac_ssh_settings_free(guac_ssh_settings* settings) {
 
     /* Free locale */
     free(settings->locale);
+
+    /* Free the client timezone. */
+    free(settings->timezone);
 
     /* Free overall structure */
     free(settings);

--- a/src/protocols/ssh/settings.h
+++ b/src/protocols/ssh/settings.h
@@ -217,6 +217,11 @@ typedef struct guac_ssh_settings {
      */
     char* locale;
 
+    /** 
+     * The client timezone to pass to the remote system.
+     */
+    char* timezone;
+
 } guac_ssh_settings;
 
 /**

--- a/src/protocols/ssh/ssh.c
+++ b/src/protocols/ssh/ssh.c
@@ -252,6 +252,17 @@ void* ssh_client_thread(void* data) {
         return NULL;
     }
 
+    /* Set the client timezone */
+    if (settings->timezone != NULL) {
+        if (libssh2_channel_setenv(ssh_client->term_channel, "TZ",
+                    settings->timezone)) {
+            guac_client_log(client, GUAC_LOG_WARNING,
+                    "Unable to set the timezone: SSH server "
+                    "refused to set \"TZ\" variable.");
+        }
+    }
+
+
 #ifdef ENABLE_SSH_AGENT
     /* Start SSH agent forwarding, if enabled */
     if (ssh_client->enable_agent) {


### PR DESCRIPTION
These changes depend on #172. The merge base will need to be updated to `glyptodon/1.x` once #172 is merged.