### PR TITLE
GLEN-259: Bring 2.x source tree for guacamole-server up-to-date with current upstream staging/1.3.0.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,5 @@ stamp-h1
 # Generated docs
 doc/doxygen-output
 
+# IDE metadata
+nbproject/

--- a/Dockerfile
+++ b/Dockerfile
@@ -75,7 +75,7 @@ RUN ${PREFIX_DIR}/bin/list-dependencies.sh    \
         > ${PREFIX_DIR}/DEPENDENCIES
 
 # Use same Debian as the base for the runtime image
-FROM debian:${DEBIAN_VERSION}
+FROM debian:${DEBIAN_VERSION}-slim
 
 # Base directory for installed build artifacts.
 # Due to limitations of the Docker image build process, this value is
@@ -90,6 +90,7 @@ ENV LD_LIBRARY_PATH=${PREFIX_DIR}/lib
 ENV GUACD_LOG_LEVEL=info
 
 ARG RUNTIME_DEPENDENCIES="            \
+        netcat-openbsd                \
         ca-certificates               \
         ghostscript                   \
         fonts-liberation              \
@@ -100,14 +101,24 @@ ARG RUNTIME_DEPENDENCIES="            \
 COPY --from=builder ${PREFIX_DIR} ${PREFIX_DIR}
 
 # Bring runtime environment up to date and install runtime dependencies
-RUN apt-get update                                          && \
-    apt-get install -y $RUNTIME_DEPENDENCIES                && \
-    apt-get install -y $(cat "${PREFIX_DIR}"/DEPENDENCIES)  && \
+RUN apt-get update                                                                  && \
+    apt-get install -y --no-install-recommends $RUNTIME_DEPENDENCIES                && \
+    apt-get install -y --no-install-recommends $(cat "${PREFIX_DIR}"/DEPENDENCIES)  && \
     rm -rf /var/lib/apt/lists/*
 
 # Link FreeRDP plugins into proper path
 RUN ${PREFIX_DIR}/bin/link-freerdp-plugins.sh \
         ${PREFIX_DIR}/lib/freerdp2/libguac*.so
+
+# Checks the operating status every 5 minutes with a timeout of 5 seconds
+HEALTHCHECK --interval=5m --timeout=5s CMD nc -z 127.0.0.1 4822 || exit 1
+
+# Create a new user guacd
+ARG UID=1000
+RUN useradd --system --create-home --shell /usr/sbin/nologin --uid $UID --no-user-group guacd
+
+# Run with user guacd
+USER guacd
 
 # Expose the default listener port
 EXPOSE 4822

--- a/bin/guacctl
+++ b/bin/guacctl
@@ -117,7 +117,7 @@ error() {
 ##
 usage() {
     cat >&2 <<END
-guacctl 1.1.0-GLEN-2.0, Apache Guacamole terminal session control utility.
+guacctl 1.3.0-GLEN-2.2, Apache Guacamole terminal session control utility.
 Usage: guacctl [OPTION] [FILE or NAME]...
 
     -d, --download         download each of the files listed.

--- a/configure.ac
+++ b/configure.ac
@@ -18,7 +18,7 @@
 #
 
 AC_PREREQ([2.61])
-AC_INIT([guacamole-server], [1.1.0-GLEN-2.1])
+AC_INIT([guacamole-server], [1.3.0-GLEN-2.2])
 AC_CONFIG_AUX_DIR([build-aux])
 AM_INIT_AUTOMAKE([-Wall -Werror foreign subdir-objects])
 AM_SILENT_RULES([yes])
@@ -201,6 +201,24 @@ then
 fi
 
 AM_CONDITIONAL([ENABLE_AVCODEC], [test "x${have_libavcodec}" = "xyes"])
+
+#
+# libavformat
+#
+
+have_libavformat=disabled
+AC_ARG_WITH([libavformat],
+	    [AS_HELP_STRING([--with-libavformat],
+	                    [use libavformat when encoding video @<:@default=check@:>@])],
+            [].
+            [with_libavformat=check])
+if test "x$with_libavformat" != "xno"
+then
+    have_libavformat=yes
+    PKG_CHECK_MODULES([AVFORMAT], [libavformat],, [have_libavformat=no]);
+fi
+
+AM_CONDITIONAL([ENABLE_AVFORMAT], [test "x${have_libavformat}" = "xyes"])
 
 #
 # libavutil
@@ -528,6 +546,33 @@ then
 fi
 
 #
+# TLS Locking Support within libVNCServer
+#
+
+if test "x${have_libvncserver}" = "xyes"
+then
+
+    have_vnc_tls_locking=yes
+    AC_CHECK_MEMBERS([rfbClient.LockWriteToTLS, rfbClient.UnlockWriteToTLS],
+                     [], [have_vnc_tls_locking=no],
+                     [[#include <rfb/rfbclient.h>]])
+
+    if test "x${have_vnc_tls_locking}" = "xno"
+    then
+        AC_MSG_WARN([
+      --------------------------------------------
+       This version of libvncclient lacks support
+       for TLS locking.  VNC connections that use
+       TLS may experience instability as documented
+       in GUACAMOLE-414])
+    else
+        AC_DEFINE([ENABLE_VNC_TLS_LOCKING],,
+                  [Whether support for TLS locking within VNC is enabled.])
+    fi
+
+fi
+
+#
 # FreeRDP 2 (libfreerdp2, libfreerdp-client2, and libwinpr2)
 #
 
@@ -578,7 +623,35 @@ then
 
 fi
 
-# Variation in memory internal allocation/free behavior
+# It is difficult or impossible to test for variations in FreeRDP behavior in
+# between releases, as the change in behavior may not (yet) be associated with
+# a corresponding change in version number and may not have any detectable
+# effect on the FreeRDP API
+if test "x${have_freerdp2}" = "xyes"
+then
+
+    AC_MSG_CHECKING([whether FreeRDP appears to be a development version])
+    AC_EGREP_CPP([\"[0-9]+\\.[0-9]+\\.[0-9]+(-rc[0-9]+)?\"], [
+
+        #include <freerdp/version.h>
+        FREERDP_VERSION_FULL
+
+    ],
+    [AC_MSG_RESULT([no])],
+    [AC_MSG_RESULT([yes])]
+    [AC_MSG_WARN([
+  --------------------------------------------
+   You are building against a development version of FreeRDP. Non-release
+   versions of FreeRDP may have differences in behavior that are impossible to
+   check for at build time. This may result in memory leaks or other strange
+   behavior.
+
+   *** PLEASE USE A RELEASED VERSION OF FREERDP IF POSSIBLE ***
+  --------------------------------------------])])
+
+fi
+
+# Variation in memory internal allocation/free behavior for bitmaps
 if test "x${have_freerdp2}" = "xyes"
 then
 
@@ -601,6 +674,29 @@ then
     [AC_MSG_RESULT([no])])
 
 fi
+
+# Variation in memory internal allocation/free behavior for channel streams
+if test "x${have_freerdp2}" = "xyes"
+then
+
+    # FreeRDP 2.0.0-rc3 through 2.0.0-rc4 automatically free the wStream
+    # provided to pVirtualChannelWriteEx(). This changed in commit 1b78b59, and
+    # implementations must manually free the wStream after it is no longer
+    # needed (after the write is complete or cancelled).
+    AC_MSG_CHECKING([whether pVirtualChannelWriteEx() frees the wStream upon completion])
+    AC_EGREP_CPP([\"2\\.0\\.0-(rc|dev)[3-4]\"], [
+
+        #include <freerdp/version.h>
+        FREERDP_VERSION_FULL
+
+    ],
+    [AC_MSG_RESULT([yes])]
+    [AC_DEFINE([FREERDP_SVC_CORE_FREES_WSTREAM],,
+               [Whether pVirtualChannelWriteEx() frees the wStream upon completion])],
+    [AC_MSG_RESULT([no])])
+
+fi
+
 
 # Glyph callback variants
 if test "x${have_freerdp2}" = "xyes"
@@ -968,10 +1064,11 @@ AC_ARG_ENABLE([guacenc],
               [],
               [enable_guacenc=yes])
 
-AM_CONDITIONAL([ENABLE_GUACENC], [test "x${enable_guacenc}"  = "xyes" \
-                                    -a "x${have_libavcodec}" = "xyes" \
-                                    -a "x${have_libavutil}"  = "xyes" \
-                                    -a "x${have_libswscale}" = "xyes"])
+AM_CONDITIONAL([ENABLE_GUACENC], [test "x${enable_guacenc}"   = "xyes" \
+                                    -a "x${have_libavcodec}"  = "xyes" \
+                                    -a "x${have_libavutil}"   = "xyes" \
+                                    -a "x${have_libswscale}"  = "xyes" \
+                                    -a "x${have_libavformat}" = "xyes"])
 
 #
 # guaclog
@@ -1064,6 +1161,7 @@ $PACKAGE_NAME version $PACKAGE_VERSION
      freerdp2 ............ ${have_freerdp2}
      pango ............... ${have_pango}
      libavcodec .......... ${have_libavcodec}
+     libavformat.......... ${have_libavformat}
      libavutil ........... ${have_libavutil}
      libssh2 ............. ${have_libssh2}
      libssl .............. ${have_ssl}

--- a/src/common-ssh/common-ssh/sftp.h
+++ b/src/common-ssh/common-ssh/sftp.h
@@ -69,6 +69,16 @@ typedef struct guac_common_ssh_sftp_filesystem {
      * instruction.
      */
     char upload_path[GUAC_COMMON_SSH_SFTP_MAX_PATH];
+    
+    /**
+     * If downloads from SFTP to the local browser should be disabled.
+     */
+    int disable_download;
+    
+    /**
+     * If uploads from the local browser to SFTP should be disabled.
+     */
+    int disable_upload;
 
 } guac_common_ssh_sftp_filesystem;
 
@@ -122,13 +132,20 @@ typedef struct guac_common_ssh_sftp_ls_state {
  *     The name to send as the name of the filesystem whenever it is exposed
  *     to a user, or NULL to automatically generate a name from the provided
  *     root_path.
+ * 
+ * @param disable_download
+ *     Whether downloads from the SFTP share to the local browser should be
+ *     disabled.
+ * 
+ * @param disable_upload
+ *     Whether uploads from the local browser to SFTP should be disabled.
  *
  * @return
  *     A new SFTP filesystem object, not yet exposed to users.
  */
 guac_common_ssh_sftp_filesystem* guac_common_ssh_create_sftp_filesystem(
         guac_common_ssh_session* session, const char* root_path,
-        const char* name);
+        const char* name, int disable_download, int disable_upload);
 
 /**
  * Destroys the given filesystem object, disconnecting from SFTP and freeing

--- a/src/common-ssh/sftp.c
+++ b/src/common-ssh/sftp.c
@@ -376,6 +376,18 @@ int guac_common_ssh_sftp_handle_file_stream(
     char fullpath[GUAC_COMMON_SSH_SFTP_MAX_PATH];
     LIBSSH2_SFTP_HANDLE* file;
 
+    /* Ignore upload if uploads have been disabled */
+    if (filesystem->disable_upload) {
+        guac_user_log(user, GUAC_LOG_WARNING, "A upload attempt has "
+                "been blocked due to uploads being disabled, however it "
+                "should have been blocked at a higher level. This is likely "
+                "a bug.");
+        guac_protocol_send_ack(user->socket, stream, "SFTP: Upload disabled",
+                GUAC_PROTOCOL_STATUS_CLIENT_FORBIDDEN);
+        guac_socket_flush(user->socket);
+        return 0;
+    }
+
     /* Concatenate filename with path */
     if (!guac_ssh_append_filename(fullpath, filesystem->upload_path,
                 filename)) {
@@ -429,7 +441,7 @@ int guac_common_ssh_sftp_handle_file_stream(
 
 /**
  * Handler for ack messages which continue an outbound SFTP data transfer
- * (download), signalling the current status and requesting additional data.
+ * (download), signaling the current status and requesting additional data.
  * The data associated with the given stream is expected to be a pointer to an
  * open LIBSSH2_SFTP_HANDLE for the file from which the data is to be read.
  *
@@ -515,6 +527,15 @@ guac_stream* guac_common_ssh_sftp_download_file(
 
     guac_stream* stream;
     LIBSSH2_SFTP_HANDLE* file;
+
+    /* Ignore download if downloads have been disabled */
+    if (filesystem->disable_download) {
+        guac_user_log(user, GUAC_LOG_WARNING, "A download attempt has "
+                "been blocked due to downloads being disabled, however it "
+                "should have been blocked at a higher level. This is likely "
+                "a bug.");
+        return NULL;
+    }
 
     /* Attempt to open file for reading */
     file = libssh2_sftp_open(filesystem->sftp_session, filename,
@@ -786,6 +807,14 @@ static int guac_common_ssh_sftp_get_handler(guac_user* user,
     /* Otherwise, send file contents */
     else {
 
+        /* If downloads are disabled, log and return. */
+        if (filesystem->disable_download) {
+            guac_user_log(user, GUAC_LOG_INFO,
+                    "Unable to download file \"%s\", "
+                    "file downloads have been disabled.", fullpath);
+            return 0;
+        }
+        
         /* Open as normal file */
         LIBSSH2_SFTP_HANDLE* file = libssh2_sftp_open(sftp, fullpath,
             LIBSSH2_FXF_READ, 0);
@@ -841,6 +870,18 @@ static int guac_common_ssh_sftp_put_handler(guac_user* user,
 
     guac_common_ssh_sftp_filesystem* filesystem =
         (guac_common_ssh_sftp_filesystem*) object->data;
+
+    /* Ignore upload if uploads have been disabled */
+    if (filesystem->disable_upload) {
+        guac_user_log(user, GUAC_LOG_WARNING, "A upload attempt has "
+                "been blocked due to uploads being disabled, however it "
+                "should have been blocked at a higher level. This is likely "
+                "a bug.");
+        guac_protocol_send_ack(user->socket, stream, "SFTP: Upload disabled",
+                GUAC_PROTOCOL_STATUS_CLIENT_FORBIDDEN);
+        guac_socket_flush(user->socket);
+        return 0;
+    }
 
     LIBSSH2_SFTP* sftp = filesystem->sftp_session;
 
@@ -902,7 +943,11 @@ guac_object* guac_common_ssh_alloc_sftp_filesystem_object(
     /* Init filesystem */
     guac_object* fs_object = guac_user_alloc_object(user);
     fs_object->get_handler = guac_common_ssh_sftp_get_handler;
-    fs_object->put_handler = guac_common_ssh_sftp_put_handler;
+    
+    /* Only handle uploads if not disabled. */
+    if (!filesystem->disable_upload)
+        fs_object->put_handler = guac_common_ssh_sftp_put_handler;
+    
     fs_object->data = filesystem;
 
     /* Send filesystem to user */
@@ -915,7 +960,7 @@ guac_object* guac_common_ssh_alloc_sftp_filesystem_object(
 
 guac_common_ssh_sftp_filesystem* guac_common_ssh_create_sftp_filesystem(
         guac_common_ssh_session* session, const char* root_path,
-        const char* name) {
+        const char* name, int disable_download, int disable_upload) {
 
     /* Request SFTP */
     LIBSSH2_SFTP* sftp_session = libssh2_sftp_init(session->session);
@@ -929,6 +974,10 @@ guac_common_ssh_sftp_filesystem* guac_common_ssh_create_sftp_filesystem(
     /* Associate SSH session with SFTP data and user */
     filesystem->ssh_session = session;
     filesystem->sftp_session = sftp_session;
+    
+    /* Copy over disable flags */
+    filesystem->disable_download = disable_download;
+    filesystem->disable_upload = disable_upload;
 
     /* Normalize and store the provided root path */
     if (!guac_common_ssh_sftp_normalize_path(filesystem->root_path,

--- a/src/common/Makefile.am
+++ b/src/common/Makefile.am
@@ -34,6 +34,7 @@ noinst_HEADERS =            \
     common/blank_cursor.h   \
     common/clipboard.h      \
     common/cursor.h         \
+    common/defaults.h       \
     common/display.h        \
     common/dot_cursor.h     \
     common/ibar_cursor.h    \

--- a/src/common/clipboard.c
+++ b/src/common/clipboard.c
@@ -46,7 +46,14 @@ guac_common_clipboard* guac_common_clipboard_alloc(int size) {
 }
 
 void guac_common_clipboard_free(guac_common_clipboard* clipboard) {
+
+    /* Destroy lock */
+    pthread_mutex_destroy(&(clipboard->lock));
+
+    /* Free buffer */
     free(clipboard->buffer);
+
+    /* Free base structure */
     free(clipboard);
 }
 

--- a/src/common/common/defaults.h
+++ b/src/common/common/defaults.h
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef GUAC_COMMON_DEFAULTS_H
+#define GUAC_COMMON_DEFAULTS_H
+
+/**
+ * The default number of seconds to wait after sending the Wake-on-LAN packet
+ * for the destination host to start responding.
+ */
+#define GUAC_WOL_DEFAULT_BOOT_WAIT_TIME 0
+
+
+#endif /* GUAC_COMMON_DEFAULTS_H */
+

--- a/src/guacd/proc.c
+++ b/src/guacd/proc.c
@@ -330,6 +330,9 @@ static void guacd_exec_proc(guacd_proc* proc, const char* protocol) {
     /* The first file descriptor is the owner */
     int owner = 1;
 
+    /* Enable keep alive on the broadcast socket */
+    guac_socket_require_keep_alive(client->socket);
+
     /* Add each received file descriptor as a new user */
     int received_fd;
     while ((received_fd = guacd_recv_fd(proc->fd_socket)) != -1) {
@@ -340,7 +343,7 @@ static void guacd_exec_proc(guacd_proc* proc, const char* protocol) {
         owner = 0;
 
     }
-
+    
 cleanup_client:
 
     /* Request client to stop/disconnect */

--- a/src/guacenc/Makefile.am
+++ b/src/guacenc/Makefile.am
@@ -90,6 +90,7 @@ endif
 guacenc_CFLAGS =            \
     -Werror -Wall           \
     @AVCODEC_CFLAGS@        \
+    @AVFORMAT_CFLAGS@       \
     @AVUTIL_CFLAGS@         \
     @LIBGUAC_INCLUDE@       \
     @SWSCALE_CFLAGS@
@@ -97,12 +98,13 @@ guacenc_CFLAGS =            \
 guacenc_LDADD =     \
     @LIBGUAC_LTLIB@
 
-guacenc_LDFLAGS =  \
-    @AVCODEC_LIBS@ \
-    @AVUTIL_LIBS@  \
-    @CAIRO_LIBS@   \
-    @JPEG_LIBS@    \
-    @SWSCALE_LIBS@ \
+guacenc_LDFLAGS =   \
+    @AVCODEC_LIBS@  \
+    @AVFORMAT_LIBS@ \
+    @AVUTIL_LIBS@   \
+    @CAIRO_LIBS@    \
+    @JPEG_LIBS@     \
+    @SWSCALE_LIBS@  \
     @WEBP_LIBS@
 
 EXTRA_DIST =         \

--- a/src/guacenc/ffmpeg-compat.c
+++ b/src/guacenc/ffmpeg-compat.c
@@ -51,8 +51,41 @@
  */
 static int guacenc_write_packet(guacenc_video* video, void* data, int size) {
 
-    /* Write data, logging any errors */
-    if (fwrite(data, 1, size, video->output) == 0) {
+    int ret;
+
+#if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(54,1,0)
+
+    AVPacket pkt;
+
+    /* Have to create a packet around the encoded data we have */
+    av_init_packet(&pkt);
+
+    if (video->context->coded_frame->pts != AV_NOPTS_VALUE) {
+        pkt.pts = av_rescale_q(video->context->coded_frame->pts,
+                video->context->time_base,
+                video->output_stream->time_base);
+    }
+    if (video->context->coded_frame->key_frame) {
+        pkt->flags |= AV_PKT_FLAG_KEY;
+    }
+
+    pkt.data = data;
+    pkt.size = size;
+    pkt.stream_index = video->output_stream->index;
+    ret = av_interleaved_write_frame(video->container_format_context, &pkt);
+
+#else
+
+    /* We know data is already a packet if we're using a newer libavcodec */
+    AVPacket* pkt = (AVPacket*) data;
+    av_packet_rescale_ts(pkt, video->context->time_base, video->output_stream->time_base);
+    pkt->stream_index = video->output_stream->index;
+    ret = av_interleaved_write_frame(video->container_format_context, pkt);
+
+#endif
+
+
+    if (ret != 0) {
         guacenc_log(GUAC_LOG_ERROR, "Unable to write frame "
                 "#%" PRId64 ": %s", video->next_pts, strerror(errno));
         return -1;
@@ -62,8 +95,7 @@ static int guacenc_write_packet(guacenc_video* video, void* data, int size) {
     guacenc_log(GUAC_LOG_DEBUG, "Frame #%08" PRId64 ": wrote %i bytes",
             video->next_pts, size);
 
-    return 0;
-
+    return ret;
 }
 
 int guacenc_avcodec_encode_video(guacenc_video* video, AVFrame* frame) {
@@ -113,6 +145,7 @@ int guacenc_avcodec_encode_video(guacenc_video* video, AVFrame* frame) {
 
 /* For libavcodec < 57.37.100: input/output was not decoupled */
 #if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(57,37,100)
+
     /* Write frame to video */
     int got_data;
     if (avcodec_encode_video2(video->context, &packet, frame, &got_data) < 0) {
@@ -123,10 +156,12 @@ int guacenc_avcodec_encode_video(guacenc_video* video, AVFrame* frame) {
 
     /* Write corresponding data to file */
     if (got_data) {
-        guacenc_write_packet(video, packet.data, packet.size);
+        guacenc_write_packet(video, (void*) &packet, packet.size);
         av_packet_unref(&packet);
     }
+
 #else
+
     /* Write frame to video */
     int result = avcodec_send_frame(video->context, frame);
 
@@ -149,10 +184,11 @@ int guacenc_avcodec_encode_video(guacenc_video* video, AVFrame* frame) {
         got_data = 1;
 
         /* Attempt to write data to output file */
-        guacenc_write_packet(video, packet.data, packet.size);
+        guacenc_write_packet(video, (void*) &packet, packet.size);
         av_packet_unref(&packet);
 
     }
+
 #endif
 
     /* Frame may have been queued for later writing / reordering */
@@ -165,3 +201,54 @@ int guacenc_avcodec_encode_video(guacenc_video* video, AVFrame* frame) {
 #endif
 }
 
+AVCodecContext* guacenc_build_avcodeccontext(AVStream* stream, AVCodec* codec, 
+        int bitrate, int width, int height, int gop_size, int qmax, int qmin,
+        int pix_fmt, AVRational time_base) {
+
+#if LIBAVFORMAT_VERSION_INT < AV_VERSION_INT(57, 33, 100)
+    stream->codec->bit_rate = bitrate;
+    stream->codec->width = width;
+    stream->codec->height = height;
+    stream->codec->gop_size = gop_size;
+    stream->codec->qmax = qmax;
+    stream->codec->qmin = qmin;
+    stream->codec->pix_fmt = pix_fmt;
+    stream->codec->time_base = time_base;
+#if LIBAVFORMAT_VERSION_INT >= AV_VERSION_INT(55, 44, 100)
+    stream->time_base = time_base;
+#endif
+    return stream->codec;
+#else
+    AVCodecContext* context = avcodec_alloc_context3(codec);
+    if (context) {
+        context->bit_rate = bitrate;
+        context->width = width;
+        context->height = height;
+        context->gop_size = gop_size;
+        context->qmax = qmax;
+        context->qmin = qmin;
+        context->pix_fmt = pix_fmt;
+        context->time_base = time_base;
+        stream->time_base = time_base;
+    }
+    return context;
+#endif
+
+}
+
+int guacenc_open_avcodec(AVCodecContext *avcodec_context,
+        AVCodec *codec, AVDictionary **options,
+        AVStream* stream) {
+
+    int ret = avcodec_open2(avcodec_context, codec, options);
+
+#if LIBAVFORMAT_VERSION_INT >= AV_VERSION_INT(57, 33, 100)
+    /* Copy stream parameters to the muxer */
+    int codecpar_ret = avcodec_parameters_from_context(stream->codecpar, avcodec_context);
+    if (codecpar_ret < 0)
+        return codecpar_ret;
+#endif
+
+    return ret;
+
+}

--- a/src/guacenc/guacenc.c
+++ b/src/guacenc/guacenc.c
@@ -25,6 +25,7 @@
 #include "parse.h"
 
 #include <libavcodec/avcodec.h>
+#include <libavformat/avformat.h>
 
 #include <getopt.h>
 #include <stdbool.h>
@@ -78,6 +79,10 @@ int main(int argc, char* argv[]) {
 #if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(58, 10, 100)
     /* Prepare libavcodec */
     avcodec_register_all();
+#endif
+
+#if LIBAVFORMAT_VERSION_INT < AV_VERSION_INT(58, 9, 100)
+    av_register_all();
 #endif
 
     /* Track number of overall failures */

--- a/src/guacenc/man/guacenc.1.in
+++ b/src/guacenc/man/guacenc.1.in
@@ -38,7 +38,7 @@ is essentially an implementation of a Guacamole client which accepts
 its input from files instead of a network connection, and renders directly to
 video instead of to the user's screen.
 .P
-Each \fIFILE\fR specified will be encoded as a raw MPEG-4 video stream to a new
+Each \fIFILE\fR specified will be encoded as MPEG-4 video to a new
 file named \fIFILE\fR.m4v, encoded according to the other options specified. By
 default, the output video will be \fI640\fRx\fI480\fR pixels, and will be saved
 with a bitrate of \fI2000000\fR bits per second (2 Mbps). These defaults can be

--- a/src/guacenc/video.c
+++ b/src/guacenc/video.c
@@ -25,6 +25,9 @@
 
 #include <cairo/cairo.h>
 #include <libavcodec/avcodec.h>
+#ifndef AVFORMAT_AVFORMAT_H
+#include <libavformat/avformat.h>
+#endif
 #include <libavutil/common.h>
 #include <libavutil/imgutils.h>
 #include <libswscale/swscale.h>
@@ -34,14 +37,30 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <assert.h>
+#include <errno.h>
 #include <fcntl.h>
 #include <inttypes.h>
-#include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include <unistd.h>
 
 guacenc_video* guacenc_video_alloc(const char* path, const char* codec_name,
         int width, int height, int bitrate) {
+
+    AVOutputFormat *container_format;
+    AVFormatContext *container_format_context;
+    AVStream *video_stream;
+    int ret;
+    int failed_header = 0;
+
+    /* allocate the output media context */
+    avformat_alloc_output_context2(&container_format_context, NULL, NULL, path);
+    if (container_format_context == NULL) {
+        guacenc_log(GUAC_LOG_ERROR, "Failed to determine container from output file name");
+        goto fail_codec;
+    }
+
+    container_format = container_format_context->oformat;
 
     /* Pull codec based on name */
     AVCodec* codec = avcodec_find_encoder_by_name(codec_name);
@@ -51,25 +70,35 @@ guacenc_video* guacenc_video_alloc(const char* path, const char* codec_name,
         goto fail_codec;
     }
 
+    /* create stream */
+    video_stream = NULL;
+    video_stream = avformat_new_stream(container_format_context, codec);
+    if (video_stream == NULL) {
+        guacenc_log(GUAC_LOG_ERROR, "Could not allocate encoder stream. Cannot continue.");
+        goto fail_format_context;
+    }
+    video_stream->id = container_format_context->nb_streams - 1;
+
     /* Retrieve encoding context */
-    AVCodecContext* context = avcodec_alloc_context3(codec);
-    if (context == NULL) {
+    AVCodecContext* avcodec_context =
+            guacenc_build_avcodeccontext(video_stream, codec, bitrate, width,
+                    height, /*gop size*/ 10, /*qmax*/ 31, /*qmin*/ 2,
+                    /*pix fmt*/ AV_PIX_FMT_YUV420P,
+                    /*time base*/ (AVRational) { 1, GUACENC_VIDEO_FRAMERATE });
+
+    if (avcodec_context == NULL) {
         guacenc_log(GUAC_LOG_ERROR, "Failed to allocate context for "
                 "codec \"%s\".", codec_name);
         goto fail_context;
     }
 
-    /* Init context with encoding parameters */
-    context->bit_rate = bitrate;
-    context->width = width;
-    context->height = height;
-    context->time_base = (AVRational) { 1, GUACENC_VIDEO_FRAMERATE };
-    context->gop_size = 10;
-    context->max_b_frames = 1;
-    context->pix_fmt = AV_PIX_FMT_YUV420P;
+    /* If format needs global headers, write them */
+    if (container_format_context->oformat->flags & AVFMT_GLOBALHEADER) {
+        avcodec_context->flags |= GUACENC_FLAG_GLOBAL_HEADER;
+    }
 
     /* Open codec for use */
-    if (avcodec_open2(context, codec, NULL) < 0) {
+    if (guacenc_open_avcodec(avcodec_context, codec, NULL, video_stream) < 0) {
         guacenc_log(GUAC_LOG_ERROR, "Failed to open codec \"%s\".", codec_name);
         goto fail_codec_open;
     }
@@ -81,9 +110,9 @@ guacenc_video* guacenc_video_alloc(const char* path, const char* codec_name,
     }
 
     /* Copy necessary data for frame from context */
-    frame->format = context->pix_fmt;
-    frame->width = context->width;
-    frame->height = context->height;
+    frame->format = avcodec_context->pix_fmt;
+    frame->width = avcodec_context->width;
+    frame->height = avcodec_context->height;
 
     /* Allocate actual backing data for frame */
     if (av_image_alloc(frame->data, frame->linesize, frame->width,
@@ -91,31 +120,32 @@ guacenc_video* guacenc_video_alloc(const char* path, const char* codec_name,
         goto fail_frame_data;
     }
 
-    /* Open output file */
-    int fd = open(path, O_CREAT | O_EXCL | O_WRONLY, S_IRUSR | S_IWUSR);
-    if (fd == -1) {
-        guacenc_log(GUAC_LOG_ERROR, "Failed to open output file \"%s\": %s",
-                path, strerror(errno));
-        goto fail_output_fd;
+    /* Open output file, if the container needs it */
+    if (!(container_format->flags & AVFMT_NOFILE)) {
+        ret = avio_open(&container_format_context->pb, path, AVIO_FLAG_WRITE);
+        if (ret < 0) {
+            guacenc_log(GUAC_LOG_ERROR, "Error occurred while opening output file.");
+            goto fail_output_avio;
+        }
     }
 
-    /* Create stream for output file */
-    FILE* output = fdopen(fd, "wb");
-    if (output == NULL) {
-        guacenc_log(GUAC_LOG_ERROR, "Failed to allocate stream for output "
-                "file \"%s\": %s", path, strerror(errno));
+    /* write the stream header, if needed */
+    ret = avformat_write_header(container_format_context, NULL);
+    if (ret < 0) {
+        guacenc_log(GUAC_LOG_ERROR, "Error occurred while writing output file header.");
+        failed_header = true;
         goto fail_output_file;
     }
 
     /* Allocate video structure */
     guacenc_video* video = malloc(sizeof(guacenc_video));
-    if (video == NULL) {
-        goto fail_video;
-    }
+    if (video == NULL)
+        goto fail_alloc_video;
 
     /* Init properties of video */
-    video->output = output;
-    video->context = context;
+    video->output_stream = video_stream;
+    video->context = avcodec_context;
+    video->container_format_context = container_format_context;
     video->next_frame = frame;
     video->width = width;
     video->height = height;
@@ -128,13 +158,16 @@ guacenc_video* guacenc_video_alloc(const char* path, const char* codec_name,
     return video;
 
     /* Free all allocated data in case of failure */
-fail_video:
-    fclose(output);
-
+fail_alloc_video:
 fail_output_file:
-    close(fd);
+    avio_close(container_format_context->pb);
 
-fail_output_fd:
+    /* Delete the file that was created if it was actually created */
+    if (unlink(path) == -1 && errno != ENOENT)
+        guacenc_log(GUAC_LOG_WARNING, "Failed output file \"%s\" could not "
+                "be automatically deleted: %s", path, strerror(errno));
+
+fail_output_avio:
     av_freep(&frame->data[0]);
 
 fail_frame_data:
@@ -142,7 +175,13 @@ fail_frame_data:
 
 fail_frame:
 fail_codec_open:
-    avcodec_free_context(&context);
+    avcodec_free_context(&avcodec_context);
+
+fail_format_context:
+    /* failing to write the container implicitly frees the context */
+    if (!failed_header) {
+        avformat_free_context(container_format_context);
+    }
 
 fail_context:
 fail_codec:
@@ -435,26 +474,34 @@ int guacenc_video_free(guacenc_video* video) {
     /* Write final frame */
     guacenc_video_flush_frame(video);
 
-    /* Init video packet for final flush of encoded data */
-    AVPacket packet;
-    av_init_packet(&packet);
-
     /* Flush any unwritten frames */
     int retval;
     do {
         retval = guacenc_video_write_frame(video, NULL);
     } while (retval > 0);
 
+    /* write trailer, if needed */
+    if (video->container_format_context != NULL &&
+            video->output_stream != NULL) {
+        guacenc_log(GUAC_LOG_DEBUG, "Writing trailer: %s",
+                av_write_trailer(video->container_format_context) == 0 ?
+                        "success" : "failure");
+    }
+
     /* File is now completely written */
-    fclose(video->output);
+    if (video->container_format_context != NULL) {
+        avio_close(video->container_format_context->pb);
+    }
 
     /* Free frame encoding data */
     av_freep(&video->next_frame->data[0]);
     av_frame_free(&video->next_frame);
 
     /* Clean up encoding context */
-    avcodec_close(video->context);
-    avcodec_free_context(&(video->context));
+    if (video->context != NULL) {
+        avcodec_close(video->context);
+        avcodec_free_context(&(video->context));
+    }
 
     free(video);
     return 0;

--- a/src/guacenc/video.h
+++ b/src/guacenc/video.h
@@ -26,6 +26,14 @@
 #include <guacamole/timestamp.h>
 #include <libavcodec/avcodec.h>
 
+#ifndef AVCODEC_AVCODEC_H
+#include <libavcodec/avcodec.h>
+#endif
+
+#ifndef AVFORMAT_AVFORMAT_H
+#include <libavformat/avformat.h>
+#endif
+
 #include <stdint.h>
 #include <stdio.h>
 
@@ -42,15 +50,23 @@
 typedef struct guacenc_video {
 
     /**
-     * Output file stream.
+     * AVStream for video output.
+     * Frames sent to this stream are written into
+     * the output file in the specified container format.
      */
-    FILE* output;
+    AVStream* output_stream;
 
     /**
      * The open encoding context from libavcodec, created for the codec
      * specified when this guacenc_video was created.
      */
     AVCodecContext* context;
+
+    /**
+     * The open format context from libavformat, created for the file
+     * container specified when this guacenc_video was created.
+     */
+    AVFormatContext* container_format_context;
 
     /**
      * The width of the video, in pixels.

--- a/src/libguac/Makefile.am
+++ b/src/libguac/Makefile.am
@@ -32,6 +32,9 @@ SUBDIRS = . tests
 libguacincdir = $(includedir)/guacamole
 
 libguacinc_HEADERS =                  \
+    guacamole/argv.h                  \
+    guacamole/argv-constants.h        \
+    guacamole/argv-fntypes.h          \
     guacamole/audio.h                 \
     guacamole/audio-fntypes.h         \
     guacamole/audio-types.h           \
@@ -69,7 +72,9 @@ libguacinc_HEADERS =                  \
     guacamole/user.h                  \
     guacamole/user-constants.h        \
     guacamole/user-fntypes.h          \
-    guacamole/user-types.h
+    guacamole/user-types.h            \
+    guacamole/wol.h                   \
+    guacamole/wol-constants.h
 
 noinst_HEADERS =      \
     id.h              \
@@ -81,6 +86,7 @@ noinst_HEADERS =      \
     wait-fd.h
 
 libguac_la_SOURCES =   \
+    argv.c             \
     audio.c            \
     client.c           \
     encode-jpeg.c      \
@@ -104,7 +110,8 @@ libguac_la_SOURCES =   \
     user.c             \
     user-handlers.c    \
     user-handshake.c   \
-    wait-fd.c
+    wait-fd.c	       \
+    wol.c
 
 # Compile WebP support if available
 if ENABLE_WEBP
@@ -128,7 +135,7 @@ libguac_la_CFLAGS = \
     -Werror -Wall -pedantic
 
 libguac_la_LDFLAGS =     \
-    -version-info 17:0:0 \
+    -version-info 19:0:0 \
     -no-undefined        \
     @CAIRO_LIBS@         \
     @DL_LIBS@            \

--- a/src/libguac/argv.c
+++ b/src/libguac/argv.c
@@ -1,0 +1,350 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "config.h"
+
+#include "guacamole/argv.h"
+#include "guacamole/client.h"
+#include "guacamole/protocol.h"
+#include "guacamole/socket.h"
+#include "guacamole/stream.h"
+#include "guacamole/string.h"
+#include "guacamole/user.h"
+
+#include <pthread.h>
+#include <stdlib.h>
+#include <string.h>
+
+/**
+ * The state of an argument that will be automatically processed. Note that
+ * this is distinct from the state of an argument value that is currently being
+ * processed. Argument value states are dynamically-allocated and scoped by the
+ * associated guac_stream.
+ */
+typedef struct guac_argv_state {
+
+    /**
+     * The name of the argument.
+     */
+    char name[GUAC_ARGV_MAX_NAME_LENGTH];
+
+    /**
+     * Whether at least one value for this argument has been received since it
+     * was registered.
+     */
+    int received;
+
+    /**
+     * Bitwise OR of all option flags that should affect processing of this
+     * argument.
+     */
+    int options;
+
+    /**
+     * The callback that should be invoked when a new value for the associated
+     * argument has been received. If the GUAC_ARGV_OPTION_ONCE flag is set,
+     * the callback will be invoked at most once.
+     */
+    guac_argv_callback* callback;
+
+    /**
+     * The arbitrary data that should be passed to the callback.
+     */
+    void* data;
+
+} guac_argv_state;
+
+/**
+ * The current state of automatic processing of "argv" streams.
+ */
+typedef struct guac_argv_await_state {
+
+    /**
+     * Whether automatic argument processing has been stopped via a call to
+     * guac_argv_stop().
+     */
+    int stopped;
+
+    /**
+     * The total number of arguments registered.
+     */
+    unsigned int num_registered;
+
+    /**
+     * All registered arguments and their corresponding callbacks.
+     */
+    guac_argv_state registered[GUAC_ARGV_MAX_REGISTERED];
+
+    /**
+     * Lock which protects multi-threaded access to this entire state
+     * structure, including the condition that signals specific modifications
+     * to the structure.
+     */
+    pthread_mutex_t lock;
+
+    /**
+     * Condition which is signalled whenever the overall state of "argv"
+     * processing changes, either through the receipt of a new argument value
+     * or due to a call to guac_argv_stop().
+     */
+    pthread_cond_t changed;
+
+} guac_argv_await_state;
+
+/**
+ * The value or current status of a connection parameter received over an
+ * "argv" stream.
+ */
+typedef struct guac_argv {
+
+    /**
+     * The state of the specific setting being updated.
+     */
+    guac_argv_state* state;
+
+    /**
+     * The mimetype of the data being received.
+     */
+    char mimetype[GUAC_ARGV_MAX_MIMETYPE_LENGTH];
+
+    /**
+     * Buffer space for containing the received argument value.
+     */
+    char buffer[GUAC_ARGV_MAX_LENGTH];
+
+    /**
+     * The number of bytes received so far.
+     */
+    int length;
+
+} guac_argv;
+
+/**
+ * Statically-allocated, shared state of the guac_argv_*() family of functions.
+ */
+static guac_argv_await_state await_state = {
+    .lock = PTHREAD_MUTEX_INITIALIZER,
+    .changed = PTHREAD_COND_INITIALIZER
+};
+
+/**
+ * Returns whether at least one value for each of the provided arguments has
+ * been received.
+ *
+ * @param args
+ *     A NULL-terminated array of the names of all arguments to test.
+ *
+ * @return
+ *     Non-zero if at least one value has been received for each of the
+ *     provided arguments, zero otherwise.
+ */
+static int guac_argv_is_received(const char** args) {
+
+    for (int i = 0; i < await_state.num_registered; i++) {
+
+        /* Ignore all received arguments */
+        guac_argv_state* state = &await_state.registered[i];
+        if (state->received)
+            continue;
+
+        /* Fail immediately for any matching non-received arguments */
+        for (const char** arg = args; *arg != NULL; arg++) {
+            if (strcmp(state->name, *arg) == 0)
+                return 0;
+        }
+
+    }
+
+    /* All arguments were received */
+    return 1;
+
+}
+
+int guac_argv_register(const char* name, guac_argv_callback* callback, void* data, int options) {
+
+    pthread_mutex_lock(&await_state.lock);
+
+    if (await_state.num_registered == GUAC_ARGV_MAX_REGISTERED) {
+        pthread_mutex_unlock(&await_state.lock);
+        return 1;
+    }
+
+    guac_argv_state* state = &await_state.registered[await_state.num_registered++];
+    guac_strlcpy(state->name, name, sizeof(state->name));
+    state->options = options;
+    state->callback = callback;
+    state->data = data;
+
+    pthread_mutex_unlock(&await_state.lock);
+    return 0;
+
+}
+
+int guac_argv_await(const char** args) {
+
+    /* Wait for all requested arguments to be received (or for receipt to be
+     * stopped) */
+    pthread_mutex_lock(&await_state.lock);
+    while (!await_state.stopped && !guac_argv_is_received(args))
+        pthread_cond_wait(&await_state.changed, &await_state.lock);
+
+    /* Arguments were successfully received only if receipt was not stopped */
+    int retval = await_state.stopped;
+    pthread_mutex_unlock(&await_state.lock);
+    return retval;
+
+}
+
+/**
+ * Handler for "blob" instructions which appends the data from received blobs
+ * to the end of the in-progress argument value buffer.
+ *
+ * @see guac_user_blob_handler
+ */
+static int guac_argv_blob_handler(guac_user* user, guac_stream* stream,
+        void* data, int length) {
+
+    guac_argv* argv = (guac_argv*) stream->data;
+
+    /* Calculate buffer size remaining, including space for null terminator,
+     * adjusting received length accordingly */
+    int remaining = sizeof(argv->buffer) - argv->length - 1;
+    if (length > remaining)
+        length = remaining;
+
+    /* Append received data to end of buffer */
+    memcpy(argv->buffer + argv->length, data, length);
+    argv->length += length;
+
+    return 0;
+
+}
+
+/**
+ * Handler for "end" instructions which applies the changes specified by the
+ * argument value buffer associated with the stream.
+ *
+ * @see guac_user_end_handler
+ */
+static int guac_argv_end_handler(guac_user* user, guac_stream* stream) {
+
+    int result = 0;
+
+    /* Append null terminator to value */
+    guac_argv* argv = (guac_argv*) stream->data;
+    argv->buffer[argv->length] = '\0';
+
+    pthread_mutex_lock(&await_state.lock);
+
+    /* Invoke callback, limiting to a single invocation if
+     * GUAC_ARGV_OPTION_ONCE applies */
+    guac_argv_state* state = argv->state;
+    if (!(state->options & GUAC_ARGV_OPTION_ONCE) || !state->received) {
+        if (state->callback != NULL)
+            result = state->callback(user, argv->mimetype, state->name, argv->buffer, state->data);
+    }
+
+    /* Alert connected clients regarding newly-accepted values if echo is
+     * enabled */
+    if (!result && (state->options & GUAC_ARGV_OPTION_ECHO)) {
+        guac_client* client = user->client;
+        guac_client_stream_argv(client, client->socket, argv->mimetype, state->name, argv->buffer);
+    }
+
+    /* Notify that argument has been received */
+    state->received = 1;
+    pthread_cond_broadcast(&await_state.changed);
+
+    pthread_mutex_unlock(&await_state.lock);
+
+    free(argv);
+    return 0;
+
+}
+
+int guac_argv_received(guac_stream* stream, const char* mimetype, const char* name) {
+
+    pthread_mutex_lock(&await_state.lock);
+
+    for (int i = 0; i < await_state.num_registered; i++) {
+
+        /* Ignore any arguments that have already been received if they are
+         * declared as being acceptable only once */
+        guac_argv_state* state = &await_state.registered[i];
+        if ((state->options & GUAC_ARGV_OPTION_ONCE) && state->received)
+            continue;
+
+        /* Argument matched */
+        if (strcmp(state->name, name) == 0) {
+
+            guac_argv* argv = malloc(sizeof(guac_argv));
+            guac_strlcpy(argv->mimetype, mimetype, sizeof(argv->mimetype));
+            argv->state = state;
+            argv->length = 0;
+
+            stream->data = argv;
+            stream->blob_handler = guac_argv_blob_handler;
+            stream->end_handler = guac_argv_end_handler;
+
+            pthread_mutex_unlock(&await_state.lock);
+            return 0;
+
+        }
+
+    }
+
+    /* No such argument awaiting processing */
+    pthread_mutex_unlock(&await_state.lock);
+    return 1;
+
+}
+
+void guac_argv_stop() {
+    pthread_mutex_lock(&await_state.lock);
+
+    /* Signal any waiting threads that no further argument values will be
+     * received */
+    if (!await_state.stopped) {
+        await_state.stopped = 1;
+        pthread_cond_broadcast(&await_state.changed);
+
+    }
+
+    pthread_mutex_unlock(&await_state.lock);
+}
+
+int guac_argv_handler(guac_user* user, guac_stream* stream,
+        char* mimetype, char* name) {
+
+    /* Refuse stream if argument is not registered */
+    if (guac_argv_received(stream, mimetype, name)) {
+        guac_protocol_send_ack(user->socket, stream, "Not allowed.",
+                GUAC_PROTOCOL_STATUS_CLIENT_FORBIDDEN);
+        guac_socket_flush(user->socket);
+        return 0;
+    }
+
+    /* Signal stream is ready */
+    guac_protocol_send_ack(user->socket, stream, "Ready for updated "
+            "parameter.", GUAC_PROTOCOL_STATUS_SUCCESS);
+    guac_socket_flush(user->socket);
+    return 0;
+
+}
+

--- a/src/libguac/guacamole/argv-constants.h
+++ b/src/libguac/guacamole/argv-constants.h
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef GUAC_ARGV_CONSTANTS_H
+#define GUAC_ARGV_CONSTANTS_H
+
+/**
+ * Constants related to automatic handling of received "argv" instructions.
+ *
+ * @file argv-constants.h
+ */
+
+/**
+ * Option flag which declares to guac_argv_register() that the associated
+ * argument should be processed exactly once. If multiple "argv" streams are
+ * received for the argument, only the first such stream is processed.
+ * Additional streams will be rejected.
+ */
+#define GUAC_ARGV_OPTION_ONCE 1
+
+/**
+ * Option flag which declares to guac_argv_register() that the values received
+ * and accepted for the associated argument should be echoed to all connected
+ * users via outbound "argv" streams.
+ */
+#define GUAC_ARGV_OPTION_ECHO 2
+
+/**
+ * The maximum number of bytes to allow for any argument value received via an
+ * argv stream and processed using guac_argv_received(), including null
+ * terminator.
+ */
+#define GUAC_ARGV_MAX_LENGTH 16384
+
+/**
+ * The maximum number of bytes to allow within the name of any argument
+ * registered with guac_argv_register(), including null terminator.
+ */
+#define GUAC_ARGV_MAX_NAME_LENGTH 256 
+
+/**
+ * The maximum number of bytes to allow within the mimetype of any received
+ * argument value passed to a callback registered with guac_argv_register(),
+ * including null terminator.
+ */
+#define GUAC_ARGV_MAX_MIMETYPE_LENGTH 4096
+
+/**
+ * The maximum number of arguments that may be registered via guac_argv_await()
+ * or guac_argv_await_async() before further argument registrations will fail.
+ */
+#define GUAC_ARGV_MAX_REGISTERED 128
+
+#endif
+

--- a/src/libguac/guacamole/argv-fntypes.h
+++ b/src/libguac/guacamole/argv-fntypes.h
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef GUAC_ARGV_FNTYPES_H
+#define GUAC_ARGV_FNTYPES_H
+
+/**
+ * Function type definitions related to automatic handling of received "argv"
+ * instructions.
+ *
+ * @file argv-fntypes.h
+ */
+
+#include "user-types.h"
+
+/**
+ * Callback which is invoked by the automatic "argv" handling when the full
+ * value of a received argument has been received.
+ *
+ * @param user
+ *     The user that opened the argument value stream.
+ *
+ * @param mimetype
+ *     The mimetype of the data that will be sent along the stream.
+ *
+ * @param name
+ *     The name of the connection parameter being updated. It is up to the
+ *     implementation of this handler to decide whether and how to update a
+ *     connection parameter.
+ *
+ * @param value
+ *     The value of the received argument.
+ *
+ * @param data
+ *     Any arbitrary data that was provided when the received argument was
+ *     registered with guac_argv_register().
+ *
+ * @return
+ *     Zero if the received argument value has been accepted and has either
+ *     taken effect or is being intentionally ignored, non-zero otherwise.
+ */
+typedef int guac_argv_callback(guac_user* user, const char* mimetype,
+        const char* name, const char* value, void* data);
+
+#endif
+

--- a/src/libguac/guacamole/argv.h
+++ b/src/libguac/guacamole/argv.h
@@ -1,0 +1,128 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef GUAC_ARGV_H
+#define GUAC_ARGV_H
+
+/**
+ * Convenience functions for processing parameter values that are submitted
+ * dynamically using "argv" instructions.
+ *
+ * @file argv.h
+ */
+
+#include "argv-constants.h"
+#include "argv-fntypes.h"
+#include "stream-types.h"
+#include "user-fntypes.h"
+
+/**
+ * Registers the given callback such that it is automatically invoked when an
+ * "argv" stream for an argument having the given name is processed using
+ * guac_argv_received(). The maximum number of arguments that may be registered
+ * in this way is limited by GUAC_ARGV_MAX_REGISTERED. The maximum length of
+ * any provided argument name is limited by GUAC_ARGV_MAX_NAME_LENGTH.
+ *
+ * @see GUAC_ARGV_MAX_NAME_LENGTH
+ * @see GUAC_ARGV_MAX_REGISTERED
+ *
+ * @see GUAC_ARGV_OPTION_ONCE
+ * @see GUAC_ARGV_OPTION_ECHO
+ *
+ * @param name
+ *     The name of the argument that should be handled by the given callback.
+ *
+ * @param callback
+ *     The callback to invoke when the value of an argument having the given
+ *     name has finished being received.
+ *
+ * @param data
+ *     Arbitrary data to be passed to the given callback when a value is
+ *     received for the given argument.
+ *
+ * @param options
+ *     Bitwise OR of all option flags that should affect processing of this
+ *     argument.
+ *
+ * @return
+ *     Zero if the callback was successfully registered, non-zero if the
+ *     maximum number of registered callbacks has already been reached.
+ */
+int guac_argv_register(const char* name, guac_argv_callback* callback, void* data, int options);
+
+/**
+ * Waits for receipt of each of the given arguments via guac_argv_received().
+ * This function will block until either ALL of the given arguments have been
+ * received via guac_argv_received() or until automatic processing of received
+ * arguments is stopped with guac_argv_stop().
+ *
+ * @param args
+ *     A NULL-terminated array of the names of all arguments that this function
+ *     should wait for.
+ *
+ * @return
+ *     Zero if all of the specified arguments were received, non-zero if
+ *     guac_argv_stop() was called before all arguments were received.
+ */
+int guac_argv_await(const char** args);
+
+/**
+ * Hands off management of the given guac_stream, automatically processing data
+ * received over that stream as the value of the argument having the given
+ * name. The argument must have already been registered with
+ * guac_argv_register(). The blob_handler and end_handler of the given stream,
+ * if already set, will be overridden without regard to their current value.
+ *
+ * It is the responsibility of the caller to properly send any required "ack"
+ * instructions to accept or reject the received stream.
+ *
+ * @param stream
+ *     The guac_stream that will receive the value of the argument having the
+ *     given name.
+ *
+ * @param mimetype
+ *     The mimetype of the data that will be received over the stream.
+ *
+ * @param name
+ *     The name of the argument being received.
+ *
+ * @return
+ *     Zero if handling of the guac_stream has been successfully handed off,
+ *     non-zero if the provided argument has not yet been registered with
+ *     guac_argv_register().
+ */
+int guac_argv_received(guac_stream* stream, const char* mimetype, const char* name);
+
+/**
+ * Stops further automatic processing of received "argv" streams. Any call to
+ * guac_argv_await() that is currently blocking will return, and any future
+ * calls to guac_argv_await() will return immediately without blocking.
+ */
+void guac_argv_stop();
+
+/**
+ * Convenience implementation of the "argv" instruction handler which
+ * automatically sends any required "ack" instructions and invokes
+ * guac_argv_received(). Only arguments that are registered with
+ * guac_argv_register() will be processed.
+ */
+guac_user_argv_handler guac_argv_handler;
+
+#endif
+

--- a/src/libguac/guacamole/client.h
+++ b/src/libguac/guacamole/client.h
@@ -550,6 +550,22 @@ int guac_client_load_plugin(guac_client* client, const char* protocol);
 int guac_client_get_processing_lag(guac_client* client);
 
 /**
+ * Sends a request to the owner of the given guac_client for parameters required
+ * to continue the connection started by the client. The function returns zero
+ * on success or non-zero on failure.
+ * 
+ * @param client
+ *     The client where additional connection parameters are required.
+ * 
+ * @param required
+ *     The NULL-terminated array of required parameters.
+ * 
+ * @return
+ *     Zero on success, non-zero on failure.
+ */
+int guac_client_owner_send_required(guac_client* client, const char** required);
+
+/**
  * Streams the given connection parameter value over an argument value stream
  * ("argv" instruction), exposing the current value of the named connection
  * parameter to all users of the given client. The argument value stream will
@@ -691,6 +707,21 @@ void guac_client_stream_jpeg(guac_client* client, guac_socket* socket,
 void guac_client_stream_webp(guac_client* client, guac_socket* socket,
         guac_composite_mode mode, const guac_layer* layer, int x, int y,
         cairo_surface_t* surface, int quality, int lossless);
+
+/**
+ * Returns whether the owner of the given client supports the "required"
+ * instruction, returning non-zero if the client owner does support the
+ * instruction, or zero if the owner does not.
+ * 
+ * @param client
+ *     The Guacamole client whose owner should be checked for supporting
+ *     the "required" instruction.
+ * 
+ * @return 
+ *     Non-zero if the owner of the given client supports the "required"
+ *     instruction, zero otherwise.
+ */
+int guac_client_owner_supports_required(guac_client* client);
 
 /**
  * Returns whether all users of the given client support WebP. If any user does

--- a/src/libguac/guacamole/protocol-constants.h
+++ b/src/libguac/guacamole/protocol-constants.h
@@ -38,7 +38,7 @@
  * This version is passed by the __guac_protocol_send_args() function from the
  * server to the client during the client/server handshake.
  */
-#define GUACAMOLE_PROTOCOL_VERSION "VERSION_1_1_0"
+#define GUACAMOLE_PROTOCOL_VERSION "VERSION_1_3_0"
 
 /**
  * The maximum number of bytes that should be sent in any one blob instruction

--- a/src/libguac/guacamole/protocol-types.h
+++ b/src/libguac/guacamole/protocol-types.h
@@ -276,5 +276,39 @@ typedef enum guac_line_join_style {
     GUAC_LINE_JOIN_ROUND = 0x2
 } guac_line_join_style;
 
+/**
+ * The set of protocol versions known to guacd to handle negotiation or feature
+ * support between differing versions of Guacamole clients and guacd.
+ */
+typedef enum guac_protocol_version {
+    
+    /**
+     * An unknown version of the Guacamole protocol.
+     */
+    GUAC_PROTOCOL_VERSION_UNKNOWN = 0x000000,
+    
+    /**
+     * Original protocol version 1.0.0, which lacks support for negotiating
+     * parameters and protocol version, and requires that parameters in the
+     * client/server handshake be delivered in order.
+     */
+    GUAC_PROTOCOL_VERSION_1_0_0 = 0x010000,
+            
+    /**
+     * Protocol version 1.1.0, which includes support for parameter and version
+     * negotiation and for sending timezone information from the client
+     * to the server.
+     */
+    GUAC_PROTOCOL_VERSION_1_1_0 = 0x010100,
+            
+    /**
+     * Protocol version 1.3.0, which supports the "required" instruction,
+     * allowing connections in guacd to request information from the client and
+     * await a response.
+     */
+    GUAC_PROTOCOL_VERSION_1_3_0 = 0x010300
+
+} guac_protocol_version;
+
 #endif
 

--- a/src/libguac/guacamole/protocol.h
+++ b/src/libguac/guacamole/protocol.h
@@ -795,6 +795,22 @@ int guac_protocol_send_rect(guac_socket* socket, const guac_layer* layer,
         int x, int y, int width, int height);
 
 /**
+ * Sends a "required" instruction over the given guac_socket connection.  This
+ * instruction indicates to the client that one or more additional parameters
+ * are needed to continue the connection.
+ * 
+ * @param socket
+ *     The guac_socket connection to which to send the instruction.
+ * 
+ * @param required
+ *     A NULL-terminated array of required parameters.
+ * 
+ * @return
+ *     Zero on success, non-zero on error.
+ */
+int guac_protocol_send_required(guac_socket* socket, const char** required);
+
+/**
  * Sends a reset instruction over the given guac_socket connection.
  *
  * If an error occurs sending the instruction, a non-zero value is
@@ -1006,6 +1022,33 @@ int guac_protocol_send_name(guac_socket* socket, const char* name);
  * @return The number of bytes resulting from the decode operation.
  */
 int guac_protocol_decode_base64(char* base64);
+
+/**
+ * Given a string representation of a protocol version, return the enum value of
+ * that protocol version, or GUAC_PROTOCOL_VERSION_UNKNOWN if the value is not a
+ * known version.
+ * 
+ * @param version_string
+ *     The string representation of the protocol version.
+ * 
+ * @return 
+ *     The enum value of the protocol version, or GUAC_PROTOCOL_VERSION_UNKNOWN
+ *     if the provided version is not known.
+ */
+guac_protocol_version guac_protocol_string_to_version(const char* version_string);
+
+/**
+ * Given the enum value of the protocol version, return a pointer to the string
+ * representation of the version, or NULL if the version is unknown.
+ * 
+ * @param version
+ *     The enum value of the protocol version.
+ * 
+ * @return 
+ *     A pointer to the string representation of the protocol version, or NULL
+ *     if the version is unknown.
+ */
+const char* guac_protocol_version_to_string(guac_protocol_version version);
 
 #endif
 

--- a/src/libguac/guacamole/string.h
+++ b/src/libguac/guacamole/string.h
@@ -110,6 +110,19 @@ size_t guac_strlcpy(char* restrict dest, const char* restrict src, size_t n);
 size_t guac_strlcat(char* restrict dest, const char* restrict src, size_t n);
 
 /**
+ * Simple wrapper for strdup() which behaves identically to standard strdup(),
+ * except that NULL will be returned if the provided string is NULL.
+ *
+ * @param str
+ *     The string to duplicate as a newly-allocated string.
+ *
+ * @return
+ *     A newly-allocated string containing identically the same content as the
+ *     given string, or NULL if the given string was NULL.
+ */
+char* guac_strdup(const char* str);
+
+/**
  * Concatenates each of the given strings, separated by the given delimiter,
  * storing the result within a destination buffer. The number of bytes written
  * will be no more than the given number of bytes, and the destination buffer

--- a/src/libguac/guacamole/user.h
+++ b/src/libguac/guacamole/user.h
@@ -95,6 +95,12 @@ struct guac_user_info {
      * is the standard tzdata naming convention.
      */
     const char* timezone;
+    
+    /**
+     * The Guacamole protocol version that the remote system supports, allowing
+     * for feature support to be negotiated between client and server.
+     */
+    guac_protocol_version protocol_version;
 
 };
 
@@ -822,6 +828,17 @@ void guac_user_stream_jpeg(guac_user* user, guac_socket* socket,
 void guac_user_stream_webp(guac_user* user, guac_socket* socket,
         guac_composite_mode mode, const guac_layer* layer, int x, int y,
         cairo_surface_t* surface, int quality, int lossless);
+
+/**
+ * Returns whether the given user supports the "required" instruction.
+ * 
+ * @param user
+ *     The Guacamole user to check for support of the "required" instruction.
+ * 
+ * @return 
+ *     Non-zero if the user supports the "required" instruction, otherwise zero.
+ */
+int guac_user_supports_required(guac_user* user);
 
 /**
  * Returns whether the given user supports WebP. If the user does not

--- a/src/libguac/guacamole/wol-constants.h
+++ b/src/libguac/guacamole/wol-constants.h
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef GUAC_WOL_CONSTANTS_H
+#define GUAC_WOL_CONSTANTS_H
+
+/**
+ * Header file that provides constants and defaults related to libguac
+ * Wake-on-LAN support.
+ * 
+ * @file wol-constants.h
+ */
+
+/**
+ * The value for the local IPv4 broadcast address.
+ */
+#define GUAC_WOL_LOCAL_IPV4_BROADCAST "255.255.255.255"
+
+/**
+ * The size of the magic Wake-on-LAN packet to send to wake a remote host.  This
+ * consists of 6 bytes of 0xFF, and then the MAC address repeated 16 times.
+ * https://en.wikipedia.org/wiki/Wake-on-LAN#Magic_packet
+ */
+#define GUAC_WOL_PACKET_SIZE 102
+
+/**
+ * The port number that the magic packet should contain as the destination.  In
+ * reality this doesn't matter all that much, since the packet is not usually
+ * processed by a full IP stack, but defining one is considered a standard
+ * practice.
+ */
+#define GUAC_WOL_PORT 9
+
+#endif /* GUAC_WOL_CONSTANTS_H */
+

--- a/src/libguac/guacamole/wol.h
+++ b/src/libguac/guacamole/wol.h
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef GUAC_WOL_H
+#define GUAC_WOL_H
+
+/**
+ * Header that provides functions and structures related to Wake-on-LAN
+ * support in libguac.
+ * 
+ * @file wol.h
+ */
+
+#include "wol-constants.h"
+
+/**
+ * Send the wake-up packet to the specified destination, returning zero if the
+ * wake was sent successfully, or non-zero if an error occurs sending the
+ * wake packet.  Note that the return value does not specify whether the
+ * system actually wakes up successfully, only whether or not the packet
+ * is transmitted.
+ * 
+ * @param mac_addr
+ *     The MAC address to place in the magic Wake-on-LAN packet.
+ * 
+ * @param broadcast_addr
+ *     The broadcast address to which to send the magic Wake-on-LAN packet.
+ * 
+ * @return 
+ *     Zero if the packet is successfully sent to the destination; non-zero
+ *     if the packet cannot be sent.
+ */
+int guac_wol_wake(const char* mac_addr, const char* broadcast_addr);
+
+#endif /* GUAC_WOL_H */
+

--- a/src/libguac/socket.c
+++ b/src/libguac/socket.c
@@ -44,6 +44,8 @@ char __guac_socket_BASE64_CHARACTERS[64] = {
 
 static void* __guac_socket_keep_alive_thread(void* data) {
 
+    int old_cancelstate;
+
     /* Calculate sleep interval */
     struct timespec interval;
     interval.tv_sec  =  GUAC_SOCKET_KEEP_ALIVE_INTERVAL / 1000;
@@ -65,8 +67,11 @@ static void* __guac_socket_keep_alive_thread(void* data) {
 
         }
 
-        /* Sleep until next keep-alive check */
+        /* Sleep until next keep-alive check, but allow thread cancellation
+         * during that sleep */
+        pthread_setcancelstate(PTHREAD_CANCEL_ENABLE, &old_cancelstate);
         nanosleep(&interval, NULL);
+        pthread_setcancelstate(PTHREAD_CANCEL_DISABLE, &old_cancelstate);
 
     }
 
@@ -202,9 +207,11 @@ void guac_socket_free(guac_socket* socket) {
     /* Mark as closed */
     socket->state = GUAC_SOCKET_CLOSED;
 
-    /* Wait for keep-alive, if enabled */
-    if (socket->__keep_alive_enabled)
+    /* Stop keep-alive thread, if enabled */
+    if (socket->__keep_alive_enabled) {
+        pthread_cancel(socket->__keep_alive_thread);
         pthread_join(socket->__keep_alive_thread, NULL);
+    }
 
     free(socket);
 }

--- a/src/libguac/string.c
+++ b/src/libguac/string.c
@@ -81,6 +81,17 @@ size_t guac_strlcat(char* restrict dest, const char* restrict src, size_t n) {
 
 }
 
+char* guac_strdup(const char* str) {
+
+    /* Return NULL if no string provided */
+    if (str == NULL)
+        return NULL;
+
+    /* Otherwise just invoke strdup() */
+    return strdup(str);
+
+}
+
 size_t guac_strljoin(char* restrict dest, const char* restrict const* elements,
         int nmemb, const char* restrict delim, size_t n) {
 

--- a/src/libguac/tests/Makefile.am
+++ b/src/libguac/tests/Makefile.am
@@ -40,8 +40,10 @@ test_libguac_SOURCES =               \
     parser/read.c                    \
     pool/next_free.c                 \
     protocol/base64_decode.c         \
+    protocol/guac_protocol_version.c \
     socket/fd_send_instruction.c     \
     socket/nested_send_instruction.c \
+    string/strdup.c                  \
     string/strlcat.c                 \
     string/strlcpy.c                 \
     string/strljoin.c                \

--- a/src/libguac/tests/protocol/guac_protocol_version.c
+++ b/src/libguac/tests/protocol/guac_protocol_version.c
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <CUnit/CUnit.h>
+#include <guacamole/protocol.h>
+#include <guacamole/protocol-types.h>
+
+/**
+ * Test which verifies that conversion of the guac_protocol_version enum to
+ * string values succeeds and produces the expected results.
+ */
+void test_guac_protocol__version_to_string() {
+    
+    guac_protocol_version version_a = GUAC_PROTOCOL_VERSION_1_3_0;
+    guac_protocol_version version_b = GUAC_PROTOCOL_VERSION_1_0_0;
+    guac_protocol_version version_c = GUAC_PROTOCOL_VERSION_UNKNOWN;
+    
+    CU_ASSERT_STRING_EQUAL(guac_protocol_version_to_string(version_a), "VERSION_1_3_0");
+    CU_ASSERT_STRING_EQUAL(guac_protocol_version_to_string(version_b), "VERSION_1_0_0");
+    CU_ASSERT_PTR_NULL(guac_protocol_version_to_string(version_c));
+    
+}
+
+/**
+ * Test which verifies that the version of String representations of Guacamole
+ * protocol versions are successfully converted into their matching
+ * guac_protocol_version enum values, and that versions that do not match
+ * any version get the correct unknown value.
+ */
+void test_guac_protocol__string_to_version() {
+    
+    char* str_version_a = "VERSION_1_3_0";
+    char* str_version_b = "VERSION_1_1_0";
+    char* str_version_c = "AVACADO";
+    char* str_version_d = "VERSION_31_4_1";
+    
+    CU_ASSERT_EQUAL(guac_protocol_string_to_version(str_version_a), GUAC_PROTOCOL_VERSION_1_3_0);
+    CU_ASSERT_EQUAL(guac_protocol_string_to_version(str_version_b), GUAC_PROTOCOL_VERSION_1_1_0);
+    CU_ASSERT_EQUAL(guac_protocol_string_to_version(str_version_c), GUAC_PROTOCOL_VERSION_UNKNOWN);
+    CU_ASSERT_EQUAL(guac_protocol_string_to_version(str_version_d), GUAC_PROTOCOL_VERSION_UNKNOWN);
+    
+}
+
+/**
+ * Test which verifies that the comparisons between guac_protocol_version enum
+ * values produces the expected results.
+ */
+void test_gauc_protocol__version_comparison() {
+    
+    CU_ASSERT_TRUE(GUAC_PROTOCOL_VERSION_1_3_0 > GUAC_PROTOCOL_VERSION_1_0_0);
+    CU_ASSERT_TRUE(GUAC_PROTOCOL_VERSION_UNKNOWN < GUAC_PROTOCOL_VERSION_1_1_0);
+    
+}

--- a/src/libguac/tests/string/strdup.c
+++ b/src/libguac/tests/string/strdup.c
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <CUnit/CUnit.h>
+#include <guacamole/string.h>
+
+#include <stdlib.h>
+#include <string.h>
+
+/**
+ * Source test string for copying.
+ */
+const char* source_string = "Mashing avocados.";
+
+/**
+ * A NULL string variable for copying to insure that NULL is copied properly.
+ */
+const char* null_string = NULL;
+
+/**
+ * Verify guac_strdup() behavior when the string is both NULL and not NULL.
+ */
+void test_string__strdup() {
+
+    /* Copy the strings. */
+    char* dest_string = guac_strdup(source_string);
+    char* null_copy = guac_strdup(null_string);
+    
+    /* Run the tests. */
+    CU_ASSERT_STRING_EQUAL(dest_string, "Mashing avocados.");
+    CU_ASSERT_PTR_NULL(null_copy);
+
+}

--- a/src/libguac/user-handshake.c
+++ b/src/libguac/user-handshake.c
@@ -344,12 +344,16 @@ int guac_user_handle_connection(guac_user* user, int usec_timeout) {
         guac_client_log(client, GUAC_LOG_INFO, "User \"%s\" joined connection "
                 "\"%s\" (%i users now present)", user->user_id,
                 client->connection_id, client->connected_users);
-        if (strcmp(parser->argv[0],"") != 0)
+        if (strcmp(parser->argv[0],"") != 0) {
             guac_client_log(client, GUAC_LOG_DEBUG, "Client is using protocol "
                     "version \"%s\"", parser->argv[0]);
-        else
+            user->info.protocol_version = guac_protocol_string_to_version(parser->argv[0]);
+        }
+        else {
             guac_client_log(client, GUAC_LOG_DEBUG, "Client has not defined "
                     "its protocol version.");
+            user->info.protocol_version = GUAC_PROTOCOL_VERSION_1_0_0;
+        }
 
         /* Handle user I/O, wait for connection to terminate */
         guac_user_start(parser, user, usec_timeout);

--- a/src/libguac/user.c
+++ b/src/libguac/user.c
@@ -316,6 +316,15 @@ void guac_user_stream_webp(guac_user* user, guac_socket* socket,
 
 }
 
+int guac_user_supports_required(guac_user* user) {
+    
+    if (user == NULL)
+        return 0;
+    
+    return (user->info.protocol_version >= GUAC_PROTOCOL_VERSION_1_3_0);
+    
+}
+
 int guac_user_supports_webp(guac_user* user) {
 
 #ifdef ENABLE_WEBP

--- a/src/libguac/wol.c
+++ b/src/libguac/wol.c
@@ -1,0 +1,193 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "config.h"
+
+#include "guacamole/error.h"
+#include "guacamole/wol.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+
+/**
+ * Generate the magic Wake-on-LAN (WoL) packet for the specified MAC address
+ * and place it in the character array.
+ * 
+ * @param packet
+ *     The character array that will contain the generated packet.
+ * 
+ * @param mac_address
+ *     The unsigned int representation of the MAC address to place in the packet.
+ */
+static void __guac_wol_create_magic_packet(unsigned char packet[],
+        unsigned int mac_address[]) {
+    
+    int i;
+    unsigned char mac[6];
+    
+    /* Concurrently fill the first part of the packet with 0xFF, and copy the
+     MAC address from the int array to the char array. */
+    for (i = 0; i < 6; i++) {
+        packet[i] = 0xFF;
+        mac[i] = mac_address[i];
+    }
+    
+    /* Copy the MAC address contents into the char array that is storing
+     the rest of the packet. */
+    for (i = 1; i <= 16; i++) {
+        memcpy(&packet[i * 6], &mac, 6 * sizeof(unsigned char));
+    }
+    
+}
+
+/**
+ * Send the magic Wake-on-LAN (WoL) packet to the specified broadcast address,
+ * returning the number of bytes sent, or zero if any error occurred and nothing
+ * was sent.
+ * 
+ * @param broadcast_addr
+ *     The broadcast address to which to send the magic WoL packet.
+ * 
+ * @param packet
+ *     The magic WoL packet to send.
+ * 
+ * @return 
+ *     The number of bytes sent, or zero if nothing could be sent.
+ */
+static ssize_t __guac_wol_send_packet(const char* broadcast_addr,
+        unsigned char packet[]) {
+    
+    struct sockaddr_in wol_dest;
+    int wol_socket;
+    
+    /* Determine the IP version, starting with IPv4. */
+    wol_dest.sin_port = htons(GUAC_WOL_PORT);
+    wol_dest.sin_family = AF_INET;
+    int retval = inet_pton(wol_dest.sin_family, broadcast_addr, &(wol_dest.sin_addr));
+    
+    /* If return value is less than zero, this system doesn't know about IPv4. */
+    if (retval < 0) {
+        guac_error = GUAC_STATUS_SEE_ERRNO;
+        guac_error_message = "IPv4 address family is not supported";
+        return 0;
+    }
+    
+    /* If return value is zero, address doesn't match the IPv4, so try IPv6. */
+    else if (retval == 0) {
+        wol_dest.sin_family = AF_INET6;
+        retval = inet_pton(wol_dest.sin_family, broadcast_addr, &(wol_dest.sin_addr));
+        
+        /* System does not support IPv6. */
+        if (retval < 0) {
+            guac_error = GUAC_STATUS_SEE_ERRNO;
+            guac_error_message = "IPv6 address family is not supported";
+            return 0;
+        }
+        
+        /* Address didn't match IPv6. */
+        else if (retval == 0) {
+            guac_error = GUAC_STATUS_INVALID_ARGUMENT;
+            guac_error_message = "Invalid broadcast or multicast address specified for Wake-on-LAN";
+            return 0;
+        }
+    }
+    
+    
+    
+    /* Set up the socket */
+    wol_socket = socket(wol_dest.sin_family, SOCK_DGRAM, 0);
+    
+    /* If socket open fails, bail out. */
+    if (wol_socket < 0) {
+        guac_error = GUAC_STATUS_SEE_ERRNO;
+        guac_error_message = "Failed to open socket to send Wake-on-LAN packet";
+        return 0;
+    }
+    
+    /* Set up socket for IPv4 broadcast. */
+    if (wol_dest.sin_family == AF_INET) {
+        
+        /* For configuring socket broadcast */
+        int wol_bcast = 1;
+
+        /* Attempt to set IPv4 broadcast; exit with error if this fails. */
+        if (setsockopt(wol_socket, SOL_SOCKET, SO_BROADCAST, &wol_bcast,
+                sizeof(wol_bcast)) < 0) {
+            close(wol_socket);
+            guac_error = GUAC_STATUS_SEE_ERRNO;
+            guac_error_message = "Failed to set IPv4 broadcast for Wake-on-LAN socket";
+            return 0;
+        }
+    }
+    
+    /* Set up socket for IPv6 multicast. */
+    else {
+        
+        /* Stick to a single hop for now. */
+        int hops = 1;
+        
+        /* Attempt to set IPv6 multicast; exit with error if this fails. */
+        if (setsockopt(wol_socket, IPPROTO_IPV6, IPV6_MULTICAST_HOPS, &hops,
+                sizeof(hops)) < 0) {
+            close(wol_socket);
+            guac_error = GUAC_STATUS_SEE_ERRNO;
+            guac_error_message = "Failed to set IPv6 multicast for Wake-on-LAN socket";
+            return 0;
+        }
+    }
+    
+    /* Send the packet and return number of bytes sent. */
+    int bytes = sendto(wol_socket, packet, GUAC_WOL_PACKET_SIZE, 0,
+            (struct sockaddr*) &wol_dest, sizeof(wol_dest));
+    close(wol_socket);
+    return bytes;
+ 
+}
+
+int guac_wol_wake(const char* mac_addr, const char* broadcast_addr) {
+    
+    unsigned char wol_packet[GUAC_WOL_PACKET_SIZE];
+    unsigned int dest_mac[6];
+    
+    /* Parse mac address and return with error if parsing fails. */
+    if (sscanf(mac_addr, "%x:%x:%x:%x:%x:%x",
+            &(dest_mac[0]), &(dest_mac[1]), &(dest_mac[2]),
+            &(dest_mac[3]), &(dest_mac[4]), &(dest_mac[5])) != 6) {
+        guac_error = GUAC_STATUS_INVALID_ARGUMENT;
+        guac_error_message = "Invalid argument for Wake-on-LAN MAC address";
+        return -1;
+    }
+    
+    /* Generate the magic packet. */
+    __guac_wol_create_magic_packet(wol_packet, dest_mac);
+    
+    /* Send the packet and record bytes sent. */
+    int bytes_sent = __guac_wol_send_packet(broadcast_addr, wol_packet);
+    
+    /* Return 0 if bytes were sent, otherwise return an error. */
+    if (bytes_sent)
+        return 0;
+    
+    return -1;
+}

--- a/src/protocols/kubernetes/argv.c
+++ b/src/protocols/kubernetes/argv.c
@@ -29,172 +29,33 @@
 #include <stdlib.h>
 #include <string.h>
 
-/**
- * All Kubernetes connection settings which may be updated by unprivileged
- * users through "argv" streams.
- */
-typedef enum guac_kubernetes_argv_setting {
-
-    /**
-     * The color scheme of the terminal.
-     */
-    GUAC_KUBERNETES_ARGV_SETTING_COLOR_SCHEME,
-
-    /**
-     * The name of the font family used by the terminal.
-     */
-    GUAC_KUBERNETES_ARGV_SETTING_FONT_NAME,
-
-    /**
-     * The size of the font used by the terminal, in points.
-     */
-    GUAC_KUBERNETES_ARGV_SETTING_FONT_SIZE
-
-} guac_kubernetes_argv_setting;
-
-/**
- * The value or current status of a connection parameter received over an
- * "argv" stream.
- */
-typedef struct guac_kubernetes_argv {
-
-    /**
-     * The specific setting being updated.
-     */
-    guac_kubernetes_argv_setting setting;
-
-    /**
-     * Buffer space for containing the received argument value.
-     */
-    char buffer[GUAC_KUBERNETES_ARGV_MAX_LENGTH];
-
-    /**
-     * The number of bytes received so far.
-     */
-    int length;
-
-} guac_kubernetes_argv;
-
-/**
- * Handler for "blob" instructions which appends the data from received blobs
- * to the end of the in-progress argument value buffer.
- *
- * @see guac_user_blob_handler
- */
-static int guac_kubernetes_argv_blob_handler(guac_user* user,
-        guac_stream* stream, void* data, int length) {
-
-    guac_kubernetes_argv* argv = (guac_kubernetes_argv*) stream->data;
-
-    /* Calculate buffer size remaining, including space for null terminator,
-     * adjusting received length accordingly */
-    int remaining = sizeof(argv->buffer) - argv->length - 1;
-    if (length > remaining)
-        length = remaining;
-
-    /* Append received data to end of buffer */
-    memcpy(argv->buffer + argv->length, data, length);
-    argv->length += length;
-
-    return 0;
-
-}
-
-/**
- * Handler for "end" instructions which applies the changes specified by the
- * argument value buffer associated with the stream.
- *
- * @see guac_user_end_handler
- */
-static int guac_kubernetes_argv_end_handler(guac_user* user,
-        guac_stream* stream) {
-
-    int size;
+int guac_kubernetes_argv_callback(guac_user* user, const char* mimetype,
+        const char* name, const char* value, void* data) {
 
     guac_client* client = user->client;
     guac_kubernetes_client* kubernetes_client = (guac_kubernetes_client*) client->data;
     guac_terminal* terminal = kubernetes_client->term;
 
-    /* Append null terminator to value */
-    guac_kubernetes_argv* argv = (guac_kubernetes_argv*) stream->data;
-    argv->buffer[argv->length] = '\0';
+    /* Update color scheme */
+    if (strcmp(name, GUAC_KUBERNETES_ARGV_COLOR_SCHEME) == 0)
+        guac_terminal_apply_color_scheme(terminal, value);
 
-    /* Apply changes to chosen setting */
-    switch (argv->setting) {
+    /* Update font name */
+    else if (strcmp(name, GUAC_KUBERNETES_ARGV_FONT_NAME) == 0)
+        guac_terminal_apply_font(terminal, value, -1, 0);
 
-        /* Update color scheme */
-        case GUAC_KUBERNETES_ARGV_SETTING_COLOR_SCHEME:
-            guac_terminal_apply_color_scheme(terminal, argv->buffer);
-            guac_client_stream_argv(client, client->socket, "text/plain",
-                    "color-scheme", argv->buffer);
-            break;
-
-        /* Update font name */
-        case GUAC_KUBERNETES_ARGV_SETTING_FONT_NAME:
-            guac_terminal_apply_font(terminal, argv->buffer, -1, 0);
-            guac_client_stream_argv(client, client->socket, "text/plain",
-                    "font-name", argv->buffer);
-            break;
-
-        /* Update font size */
-        case GUAC_KUBERNETES_ARGV_SETTING_FONT_SIZE:
-
-            /* Update only if font size is sane */
-            size = atoi(argv->buffer);
-            if (size > 0) {
-                guac_terminal_apply_font(terminal, NULL, size,
-                        kubernetes_client->settings->resolution);
-                guac_client_stream_argv(client, client->socket, "text/plain",
-                        "font-size", argv->buffer);
-            }
-
-            break;
-
+    /* Update only if font size is sane */
+    else if (strcmp(name, GUAC_KUBERNETES_ARGV_FONT_SIZE) == 0) {
+        int size = atoi(value);
+        if (size > 0)
+            guac_terminal_apply_font(terminal, NULL, size,
+                    kubernetes_client->settings->resolution);
     }
 
     /* Update Kubernetes terminal size */
     guac_kubernetes_resize(client, terminal->term_height,
             terminal->term_width);
 
-    free(argv);
-    return 0;
-
-}
-
-int guac_kubernetes_argv_handler(guac_user* user, guac_stream* stream,
-        char* mimetype, char* name) {
-
-    guac_kubernetes_argv_setting setting;
-
-    /* Allow users to update the color scheme and font details */
-    if (strcmp(name, "color-scheme") == 0)
-        setting = GUAC_KUBERNETES_ARGV_SETTING_COLOR_SCHEME;
-    else if (strcmp(name, "font-name") == 0)
-        setting = GUAC_KUBERNETES_ARGV_SETTING_FONT_NAME;
-    else if (strcmp(name, "font-size") == 0)
-        setting = GUAC_KUBERNETES_ARGV_SETTING_FONT_SIZE;
-
-    /* No other connection parameters may be updated */
-    else {
-        guac_protocol_send_ack(user->socket, stream, "Not allowed.",
-                GUAC_PROTOCOL_STATUS_CLIENT_FORBIDDEN);
-        guac_socket_flush(user->socket);
-        return 0;
-    }
-
-    guac_kubernetes_argv* argv = malloc(sizeof(guac_kubernetes_argv));
-    argv->setting = setting;
-    argv->length = 0;
-
-    /* Prepare stream to receive argument value */
-    stream->blob_handler = guac_kubernetes_argv_blob_handler;
-    stream->end_handler = guac_kubernetes_argv_end_handler;
-    stream->data = argv;
-
-    /* Signal stream is ready */
-    guac_protocol_send_ack(user->socket, stream, "Ready for updated "
-            "parameter.", GUAC_PROTOCOL_STATUS_SUCCESS);
-    guac_socket_flush(user->socket);
     return 0;
 
 }
@@ -205,20 +66,21 @@ void* guac_kubernetes_send_current_argv(guac_user* user, void* data) {
     guac_terminal* terminal = kubernetes_client->term;
 
     /* Send current color scheme */
-    guac_user_stream_argv(user, user->socket, "text/plain", "color-scheme",
-            terminal->color_scheme);
+    guac_user_stream_argv(user, user->socket, "text/plain",
+            GUAC_KUBERNETES_ARGV_COLOR_SCHEME, terminal->color_scheme);
 
     /* Send current font name */
-    guac_user_stream_argv(user, user->socket, "text/plain", "font-name",
-            terminal->font_name);
+    guac_user_stream_argv(user, user->socket, "text/plain",
+            GUAC_KUBERNETES_ARGV_FONT_NAME, terminal->font_name);
 
     /* Send current font size */
     char font_size[64];
     sprintf(font_size, "%i", terminal->font_size);
-    guac_user_stream_argv(user, user->socket, "text/plain", "font-size",
-            font_size);
+    guac_user_stream_argv(user, user->socket, "text/plain",
+            GUAC_KUBERNETES_ARGV_FONT_SIZE, font_size);
 
     return NULL;
+
 
 }
 

--- a/src/protocols/kubernetes/argv.h
+++ b/src/protocols/kubernetes/argv.h
@@ -23,19 +23,32 @@
 
 #include "config.h"
 
+#include <guacamole/argv.h>
 #include <guacamole/user.h>
 
 /**
- * The maximum number of bytes to allow for any argument value received via an
- * argv stream, including null terminator.
+ * The name of the parameter that specifies/updates the color scheme used by
+ * the terminal emulator.
  */
-#define GUAC_KUBERNETES_ARGV_MAX_LENGTH 16384
+#define GUAC_KUBERNETES_ARGV_COLOR_SCHEME "color-scheme"
 
 /**
- * Handles an incoming stream from a Guacamole "argv" instruction, updating the
- * given connection parameter if that parameter is allowed to be updated.
+ * The name of the parameter that specifies/updates the name of the font used
+ * by the terminal emulator.
  */
-guac_user_argv_handler guac_kubernetes_argv_handler;
+#define GUAC_KUBERNETES_ARGV_FONT_NAME "font-name"
+
+/**
+ * The name of the parameter that specifies/updates the font size used by the
+ * terminal emulator.
+ */
+#define GUAC_KUBERNETES_ARGV_FONT_SIZE "font-size"
+
+/**
+ * Handles a received argument value from a Guacamole "argv" instruction,
+ * updating the given connection parameter.
+ */
+guac_argv_callback guac_kubernetes_argv_callback;
 
 /**
  * Sends the current values of all non-sensitive parameters which may be set

--- a/src/protocols/kubernetes/client.c
+++ b/src/protocols/kubernetes/client.c
@@ -17,12 +17,14 @@
  * under the License.
  */
 
+#include "argv.h"
 #include "client.h"
 #include "common/clipboard.h"
 #include "kubernetes.h"
 #include "settings.h"
 #include "user.h"
 
+#include <guacamole/argv.h>
 #include <guacamole/client.h>
 #include <libwebsockets.h>
 
@@ -99,6 +101,11 @@ int guac_client_init(guac_client* client) {
     /* Set handlers */
     client->join_handler = guac_kubernetes_user_join_handler;
     client->free_handler = guac_kubernetes_client_free_handler;
+
+    /* Register handlers for argument values that may be sent after the handshake */
+    guac_argv_register(GUAC_KUBERNETES_ARGV_COLOR_SCHEME, guac_kubernetes_argv_callback, NULL, GUAC_ARGV_OPTION_ECHO);
+    guac_argv_register(GUAC_KUBERNETES_ARGV_FONT_NAME, guac_kubernetes_argv_callback, NULL, GUAC_ARGV_OPTION_ECHO);
+    guac_argv_register(GUAC_KUBERNETES_ARGV_FONT_SIZE, guac_kubernetes_argv_callback, NULL, GUAC_ARGV_OPTION_ECHO);
 
     /* Set locale and warn if not UTF-8 */
     setlocale(LC_CTYPE, "");

--- a/src/protocols/kubernetes/settings.c
+++ b/src/protocols/kubernetes/settings.c
@@ -17,6 +17,7 @@
  * under the License.
  */
 
+#include "argv.h"
 #include "settings.h"
 
 #include <guacamole/user.h>
@@ -35,9 +36,9 @@ const char* GUAC_KUBERNETES_CLIENT_ARGS[] = {
     "client-key",
     "ca-cert",
     "ignore-cert",
-    "font-name",
-    "font-size",
-    "color-scheme",
+    GUAC_KUBERNETES_ARGV_FONT_NAME,
+    GUAC_KUBERNETES_ARGV_FONT_SIZE,
+    GUAC_KUBERNETES_ARGV_COLOR_SCHEME,
     "typescript-path",
     "typescript-name",
     "create-typescript-path",

--- a/src/protocols/kubernetes/user.c
+++ b/src/protocols/kubernetes/user.c
@@ -93,7 +93,7 @@ int guac_kubernetes_user_join_handler(guac_user* user, int argc, char** argv) {
         user->pipe_handler = guac_kubernetes_pipe_handler;
 
         /* Updates to connection parameters */
-        user->argv_handler = guac_kubernetes_argv_handler;
+        user->argv_handler = guac_argv_handler;
 
         /* Display size change events */
         user->size_handler = guac_kubernetes_user_size_handler;

--- a/src/protocols/rdp/Makefile.am
+++ b/src/protocols/rdp/Makefile.am
@@ -38,6 +38,7 @@ nodist_libguac_client_rdp_la_SOURCES =  \
     _generated_keymaps.c
 
 libguac_client_rdp_la_SOURCES =                  \
+    argv.c                                       \
     beep.c                                       \
     bitmap.c                                     \
     channels/audio-input/audio-buffer.c          \
@@ -82,6 +83,7 @@ libguac_client_rdp_la_SOURCES =                  \
     user.c
 
 noinst_HEADERS =                                 \
+    argv.h                                       \
     beep.h                                       \
     bitmap.h                                     \
     channels/audio-input/audio-buffer.h          \

--- a/src/protocols/rdp/argv.c
+++ b/src/protocols/rdp/argv.c
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "config.h"
+#include "argv.h"
+#include "rdp.h"
+#include "settings.h"
+
+#include <guacamole/protocol.h>
+#include <guacamole/socket.h>
+#include <guacamole/user.h>
+
+#include <pthread.h>
+#include <stdlib.h>
+#include <string.h>
+
+int guac_rdp_argv_callback(guac_user* user, const char* mimetype,
+        const char* name, const char* value, void* data) {
+
+    guac_client* client = user->client;
+    guac_rdp_client* rdp_client = (guac_rdp_client*) client->data;
+    guac_rdp_settings* settings = rdp_client->settings;
+
+    /* Update username */
+    if (strcmp(name, GUAC_RDP_ARGV_USERNAME) == 0) {
+        free(settings->username);
+        settings->username = strdup(value);
+    }
+    
+    /* Update password */
+    else if (strcmp(name, GUAC_RDP_ARGV_PASSWORD) == 0) {
+        free(settings->password);
+        settings->password = strdup(value);
+    }
+    
+    /* Update domain */
+    else if (strcmp(name, GUAC_RDP_ARGV_DOMAIN) == 0) {
+        free(settings->domain);
+        settings->domain = strdup(value);
+    }
+
+    return 0;
+
+}

--- a/src/protocols/rdp/argv.h
+++ b/src/protocols/rdp/argv.h
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+#ifndef GUAC_RDP_ARGV_H
+#define GUAC_RDP_ARGV_H
+
+#include "config.h"
+
+#include <guacamole/argv.h>
+#include <guacamole/user.h>
+
+/**
+ * Handles a received argument value from a Guacamole "argv" instruction,
+ * updating the given connection parameter.
+ */
+guac_argv_callback guac_rdp_argv_callback;
+
+/**
+ * The name of the parameter that specifies/updates the username that will be
+ * sent to the RDP server during authentication.
+ */
+#define GUAC_RDP_ARGV_USERNAME "username"
+
+/**
+ * The name of the parameter that specifies/updates the password that will be
+ * sent to the RDP server during authentication.
+ */
+#define GUAC_RDP_ARGV_PASSWORD "password"
+
+/**
+ * The name of the parameter that specifies/updates the domain name that will be
+ * sent to the RDP server during authentication.
+ */
+#define GUAC_RDP_ARGV_DOMAIN "domain"
+
+#endif
+

--- a/src/protocols/rdp/channels/common-svc.c
+++ b/src/protocols/rdp/channels/common-svc.c
@@ -89,10 +89,9 @@ void guac_rdp_common_svc_write(guac_rdp_common_svc* svc,
         return;
     }
 
-    /* NOTE: Data sent via pVirtualChannelWriteEx MUST always be dynamically
-     * allocated, as it will be automatically freed using free(). If provided,
-     * the last parameter (user data) MUST be a pointer to a wStream, as it
-     * will automatically be freed by FreeRDP using Stream_Free() */
+    /* NOTE: The wStream sent via pVirtualChannelWriteEx will automatically be
+     * freed later with a call to Stream_Free() when handling the
+     * corresponding write cancel/completion event. */
     svc->_entry_points.pVirtualChannelWriteEx(svc->_init_handle,
             svc->_open_handle, Stream_Buffer(output_stream),
             Stream_GetPosition(output_stream), output_stream);

--- a/src/protocols/rdp/channels/rdpdr/rdpdr-fs-messages-file-info.c
+++ b/src/protocols/rdp/channels/rdpdr/rdpdr-fs-messages-file-info.c
@@ -166,7 +166,8 @@ void guac_rdpdr_fs_process_set_rename_info(guac_rdp_common_svc* svc,
             destination_path);
 
     /* If file moving to \Download folder, start stream, do not move */
-    if (strncmp(destination_path, "\\Download\\", 10) == 0) {
+    if (strncmp(destination_path, "\\Download\\", 10) == 0
+			&& !((guac_rdp_fs*) device->data)->disable_download) {
 
         guac_rdp_fs_file* file;
 

--- a/src/protocols/rdp/channels/rdpdr/rdpdr-fs-messages.c
+++ b/src/protocols/rdp/channels/rdpdr/rdpdr-fs-messages.c
@@ -114,12 +114,17 @@ void guac_rdpdr_fs_process_create(guac_rdp_common_svc* svc,
         /* Create \Download if it doesn't exist */
         file = guac_rdp_fs_get_file((guac_rdp_fs*) device->data, file_id);
         if (file != NULL && strcmp(file->absolute_path, "\\") == 0) {
-            int download_id =
-                guac_rdp_fs_open((guac_rdp_fs*) device->data, "\\Download",
-                    GENERIC_READ, 0, FILE_OPEN_IF, FILE_DIRECTORY_FILE);
+            
+            /* Only create Download folder if downloads are enabled. */
+            if (!((guac_rdp_fs*) device->data)->disable_download) {
+                int download_id =
+                    guac_rdp_fs_open((guac_rdp_fs*) device->data, "\\Download",
+                        GENERIC_READ, 0, FILE_OPEN_IF, FILE_DIRECTORY_FILE);
+                
+                if (download_id >= 0)
+                    guac_rdp_fs_close((guac_rdp_fs*) device->data, download_id);
+            }
 
-            if (download_id >= 0)
-                guac_rdp_fs_close((guac_rdp_fs*) device->data, download_id);
         }
 
     }
@@ -261,8 +266,9 @@ void guac_rdpdr_fs_process_close(guac_rdp_common_svc* svc,
         return;
 
     /* If file was written to, and it's in the \Download folder, start stream */
-    if (file->bytes_written > 0 &&
-            strncmp(file->absolute_path, "\\Download\\", 10) == 0) {
+    if (file->bytes_written > 0
+            && strncmp(file->absolute_path, "\\Download\\", 10) == 0
+			&& !((guac_rdp_fs*) device->data)->disable_download) {
         guac_client_for_owner(svc->client, guac_rdp_download_to_user, file->absolute_path);
         guac_rdp_fs_delete((guac_rdp_fs*) device->data, iorequest->file_id);
     }

--- a/src/protocols/rdp/download.c
+++ b/src/protocols/rdp/download.c
@@ -148,8 +148,8 @@ int guac_rdp_download_get_handler(guac_user* user, guac_object* object,
 
     }
 
-    /* Otherwise, send file contents */
-    else {
+    /* Otherwise, send file contents if downloads are allowed */
+    else if (!fs->disable_download) {
 
         /* Create stream data */
         guac_rdp_download_status* download_status = malloc(sizeof(guac_rdp_download_status));
@@ -166,6 +166,10 @@ int guac_rdp_download_get_handler(guac_user* user, guac_object* object,
                 "application/octet-stream", name);
 
     }
+
+    else
+        guac_client_log(client, GUAC_LOG_INFO, "Unable to download file "
+                "\"%s\", file downloads have been disabled.", name);
 
     guac_socket_flush(user->socket);
     return 0;
@@ -184,6 +188,15 @@ void* guac_rdp_download_to_user(guac_user* user, void* data) {
     /* Ignore download if filesystem has been unloaded */
     if (filesystem == NULL)
         return NULL;
+
+    /* Ignore download if downloads have been disabled */
+    if (filesystem->disable_download) {
+        guac_client_log(client, GUAC_LOG_WARNING, "A download attempt has "
+                "been blocked due to downloads being disabled, however it "
+                "should have been blocked at a higher level. This is likely "
+                "a bug.");
+        return NULL;
+    }
 
     /* Attempt to open requested file */
     char* path = (char*) data;

--- a/src/protocols/rdp/error.c
+++ b/src/protocols/rdp/error.c
@@ -18,14 +18,187 @@
  */
 
 #include "error.h"
-#include "rdp.h"
 
 #include <freerdp/freerdp.h>
 #include <guacamole/client.h>
 #include <guacamole/protocol.h>
 #include <guacamole/socket.h>
+#include <winpr/wtypes.h>
 
-void guac_rdp_client_abort(guac_client* client) {
+/**
+ * Translates the error code returned by freerdp_get_last_error() for the given
+ * RDP instance into a Guacamole status code and human-readable message. If no
+ * error was reported, a successful error code and message will be assigned.
+ *
+ * @param rdp_inst
+ *     The FreeRDP client instance handling the RDP connection that failed.
+ *
+ * @param status
+ *     Pointer to the variable that should receive the guac_protocol_status
+ *     value equivalent to the error returned by freerdp_get_last_error().
+ *
+ * @param message
+ *     Pointer to the variable that should receive a static human-readable
+ *     message generally describing the error returned by
+ *     freerdp_get_last_error().
+ */
+static void guac_rdp_translate_last_error(freerdp* rdp_inst,
+        guac_protocol_status* status, const char** message) {
+
+    UINT32 last_error = freerdp_get_last_error(rdp_inst->context);
+    switch (last_error) {
+
+        /*
+         * Normal disconnect (no error at all)
+         */
+
+        case FREERDP_ERROR_NONE:
+        case FREERDP_ERROR_SUCCESS:
+            *status = GUAC_PROTOCOL_STATUS_SUCCESS;
+            *message = "Disconnected.";
+            break;
+
+        /*
+         * General credentials expired (password has expired, password must be
+         * reset before it can be used for the first time, etc.)
+         */
+
+#ifdef FREERDP_ERROR_CONNECT_ACCOUNT_EXPIRED
+        case FREERDP_ERROR_CONNECT_ACCOUNT_EXPIRED:
+#endif
+
+#ifdef FREERDP_ERROR_CONNECT_PASSWORD_MUST_CHANGE
+        case FREERDP_ERROR_CONNECT_PASSWORD_MUST_CHANGE:
+#endif
+
+        case FREERDP_ERROR_CONNECT_PASSWORD_CERTAINLY_EXPIRED:
+        case FREERDP_ERROR_CONNECT_PASSWORD_EXPIRED:
+        case FREERDP_ERROR_SERVER_FRESH_CREDENTIALS_REQUIRED:
+            *status = GUAC_PROTOCOL_STATUS_CLIENT_FORBIDDEN;
+            *message = "Credentials expired.";
+            break;
+
+        /*
+         * Security negotiation failed (the server is refusing the connection
+         * because the security negotiation process failed)
+         */
+
+        case FREERDP_ERROR_SECURITY_NEGO_CONNECT_FAILED:
+            *status = GUAC_PROTOCOL_STATUS_CLIENT_UNAUTHORIZED;
+            *message = "Security negotiation failed (wrong security type?)";
+            break;
+
+        /*
+         * General access denied/revoked (regardless of any credentials
+         * provided, the server is denying the requested access by this
+         * account)
+         */
+
+#ifdef FREERDP_ERROR_CONNECT_ACCESS_DENIED
+        case FREERDP_ERROR_CONNECT_ACCESS_DENIED:
+#endif
+
+#ifdef FREERDP_ERROR_CONNECT_ACCOUNT_DISABLED
+        case FREERDP_ERROR_CONNECT_ACCOUNT_DISABLED:
+#endif
+
+#ifdef FREERDP_ERROR_CONNECT_ACCOUNT_LOCKED_OUT
+        case FREERDP_ERROR_CONNECT_ACCOUNT_LOCKED_OUT:
+#endif
+
+#ifdef FREERDP_ERROR_CONNECT_ACCOUNT_RESTRICTION
+        case FREERDP_ERROR_CONNECT_ACCOUNT_RESTRICTION:
+#endif
+
+#ifdef FREERDP_ERROR_CONNECT_LOGON_TYPE_NOT_GRANTED
+        case FREERDP_ERROR_CONNECT_LOGON_TYPE_NOT_GRANTED:
+#endif
+
+        case FREERDP_ERROR_CONNECT_CLIENT_REVOKED:
+        case FREERDP_ERROR_INSUFFICIENT_PRIVILEGES:
+        case FREERDP_ERROR_SERVER_DENIED_CONNECTION:
+        case FREERDP_ERROR_SERVER_INSUFFICIENT_PRIVILEGES:
+            *status = GUAC_PROTOCOL_STATUS_CLIENT_FORBIDDEN;
+            *message = "Access denied by server (account locked/disabled?)";
+            break;
+
+        /*
+         * General authentication failure (no credentials provided or wrong
+         * credentials provided)
+         */
+
+#ifdef FREERDP_ERROR_CONNECT_NO_OR_MISSING_CREDENTIALS
+        case FREERDP_ERROR_CONNECT_NO_OR_MISSING_CREDENTIALS:
+#endif
+
+#ifdef FREERDP_ERROR_CONNECT_LOGON_FAILURE
+        case FREERDP_ERROR_CONNECT_LOGON_FAILURE:
+#endif
+
+#ifdef FREERDP_ERROR_CONNECT_WRONG_PASSWORD
+        case FREERDP_ERROR_CONNECT_WRONG_PASSWORD:
+#endif
+
+        case FREERDP_ERROR_AUTHENTICATION_FAILED:
+            *status = GUAC_PROTOCOL_STATUS_CLIENT_UNAUTHORIZED;
+            *message = "Authentication failure (invalid credentials?)";
+            break;
+
+        /*
+         * SSL/TLS connection failed (the server's certificate is not trusted)
+         */
+
+        case FREERDP_ERROR_TLS_CONNECT_FAILED:
+            *status = GUAC_PROTOCOL_STATUS_UPSTREAM_NOT_FOUND;
+            *message = "SSL/TLS connection failed (untrusted/self-signed certificate?)";
+            break;
+
+        /*
+         * DNS lookup failed (hostname resolution failed or invalid IP address)
+         */
+
+        case FREERDP_ERROR_DNS_ERROR:
+        case FREERDP_ERROR_DNS_NAME_NOT_FOUND:
+            *status = GUAC_PROTOCOL_STATUS_UPSTREAM_NOT_FOUND;
+            *message = "DNS lookup failed (incorrect hostname?)";
+            break;
+
+        /*
+         * Connection refused (the server is outright refusing to handle the
+         * inbound connection, typically due to the client requesting a
+         * security type that is not allowed)
+         */
+
+        case FREERDP_ERROR_CONNECT_TRANSPORT_FAILED:
+            *status = GUAC_PROTOCOL_STATUS_UPSTREAM_NOT_FOUND;
+            *message = "Server refused connection (wrong security type?)";
+            break;
+
+        /*
+         * Connection failed (the network connection to the server did not
+         * succeed)
+         */
+
+        case FREERDP_ERROR_CONNECT_CANCELLED:
+        case FREERDP_ERROR_CONNECT_FAILED:
+        case FREERDP_ERROR_CONNECT_KDC_UNREACHABLE:
+        case FREERDP_ERROR_MCS_CONNECT_INITIAL_ERROR:
+            *status = GUAC_PROTOCOL_STATUS_UPSTREAM_NOT_FOUND;
+            *message = "Connection failed (server unreachable?)";
+            break;
+
+        /*
+         * All other (unknown) errors
+         */
+        default:
+            *status = GUAC_PROTOCOL_STATUS_UPSTREAM_ERROR;
+            *message = "Upstream error.";
+
+    }
+
+}
+
+void guac_rdp_client_abort(guac_client* client, freerdp* rdp_inst) {
 
     /*
      * NOTE: The RDP status codes translated here are documented within
@@ -34,9 +207,6 @@ void guac_rdp_client_abort(guac_client* client) {
      *
      * https://msdn.microsoft.com/en-us/library/cc240544.aspx
      */
-
-    guac_rdp_client* rdp_client = (guac_rdp_client*) client->data;
-    freerdp* rdp_inst = rdp_client->rdp_inst;
 
     guac_protocol_status status;
     const char* message;
@@ -47,10 +217,9 @@ void guac_rdp_client_abort(guac_client* client) {
     /* Translate reason code into Guacamole protocol status */
     switch (error_info) {
 
-        /* Normal disconnect */
+        /* Possibly-normal disconnect, depending on freerdp_get_last_error() */
         case 0x0: /* ERRINFO_SUCCESS */
-            status = GUAC_PROTOCOL_STATUS_SUCCESS;
-            message = "Disconnected.";
+            guac_rdp_translate_last_error(rdp_inst, &status, &message);
             break;
 
         /* Forced disconnect (possibly by admin) */
@@ -129,8 +298,8 @@ void guac_rdp_client_abort(guac_client* client) {
     }
 
     /* Log human-readable description of disconnect at info level */
-    guac_client_log(client, GUAC_LOG_INFO, "RDP server closed connection: %s",
-            message);
+    guac_client_log(client, GUAC_LOG_INFO, "RDP server closed/refused "
+            "connection: %s", message);
 
     /* Log internal disconnect reason code at debug level */
     if (error_info)

--- a/src/protocols/rdp/error.h
+++ b/src/protocols/rdp/error.h
@@ -20,17 +20,22 @@
 #ifndef GUAC_RDP_ERROR_H
 #define GUAC_RDP_ERROR_H
 
+#include <freerdp/freerdp.h>
 #include <guacamole/client.h>
 
 /**
- * Stops the current connection due to the RDP server disconnecting. If the RDP
- * server provided a reason for disconnecting, that reason will be logged, and
- * an appropriate error code will be sent to the Guacamole client.
+ * Stops the current connection due to the RDP server disconnecting or the
+ * connection attempt failing. If the RDP server or FreeRDP provided a reason
+ * for for the failure/disconnect, that reason will be logged, and an
+ * appropriate error code will be sent to the Guacamole client.
  *
  * @param client
  *     The Guacamole client to disconnect.
+ *
+ * @param rdp_inst
+ *     The FreeRDP client instance handling the RDP connection that failed.
  */
-void guac_rdp_client_abort(guac_client* client);
+void guac_rdp_client_abort(guac_client* client, freerdp* rdp_inst);
 
 #endif
 

--- a/src/protocols/rdp/fs.c
+++ b/src/protocols/rdp/fs.c
@@ -43,7 +43,7 @@
 #include <unistd.h>
 
 guac_rdp_fs* guac_rdp_fs_alloc(guac_client* client, const char* drive_path,
-        int create_drive_path) {
+        int create_drive_path, int disable_download, int disable_upload) {
 
     /* Create drive path if it does not exist */
     if (create_drive_path) {
@@ -65,6 +65,8 @@ guac_rdp_fs* guac_rdp_fs_alloc(guac_client* client, const char* drive_path,
     fs->drive_path = strdup(drive_path);
     fs->file_id_pool = guac_pool_alloc(0);
     fs->open_files = 0;
+    fs->disable_download = disable_download;
+    fs->disable_upload = disable_upload;
 
     return fs;
 
@@ -77,11 +79,15 @@ void guac_rdp_fs_free(guac_rdp_fs* fs) {
 }
 
 guac_object* guac_rdp_fs_alloc_object(guac_rdp_fs* fs, guac_user* user) {
-
+    
     /* Init filesystem */
     guac_object* fs_object = guac_user_alloc_object(user);
     fs_object->get_handler = guac_rdp_download_get_handler;
-    fs_object->put_handler = guac_rdp_upload_put_handler;
+    
+    /* Assign handler only if uploads are not disabled. */
+    if (!fs->disable_upload)
+        fs_object->put_handler = guac_rdp_upload_put_handler;
+    
     fs_object->data = fs;
 
     /* Send filesystem to user */
@@ -403,7 +409,7 @@ int guac_rdp_fs_open(guac_rdp_fs* fs, const char* path,
 
 }
 
-int guac_rdp_fs_read(guac_rdp_fs* fs, int file_id, int offset,
+int guac_rdp_fs_read(guac_rdp_fs* fs, int file_id, uint64_t offset,
         void* buffer, int length) {
 
     int bytes_read;
@@ -427,7 +433,7 @@ int guac_rdp_fs_read(guac_rdp_fs* fs, int file_id, int offset,
 
 }
 
-int guac_rdp_fs_write(guac_rdp_fs* fs, int file_id, int offset,
+int guac_rdp_fs_write(guac_rdp_fs* fs, int file_id, uint64_t offset,
         void* buffer, int length) {
 
     int bytes_written;

--- a/src/protocols/rdp/print-job.c
+++ b/src/protocols/rdp/print-job.c
@@ -631,6 +631,9 @@ void guac_rdp_print_job_free(guac_rdp_print_job* job) {
     /* Wait for job to terminate */
     pthread_join(job->output_thread, NULL);
 
+    /* Destroy lock */
+    pthread_mutex_destroy(&(job->state_lock));
+
     /* Free base structure */
     free(job);
 

--- a/src/protocols/rdp/settings.h
+++ b/src/protocols/rdp/settings.h
@@ -228,6 +228,16 @@ typedef struct guac_rdp_settings {
      * exist.
      */
     int create_drive_path;
+    
+    /**
+     * Whether or not to disable file download over RDP.
+     */
+    int disable_download;
+    
+    /**
+     * Wether or not to disable file upload over RDP.
+     */
+    int disable_upload;
 
     /**
      * Whether this session is a console session.
@@ -387,7 +397,7 @@ typedef struct guac_rdp_settings {
 
 #ifdef ENABLE_COMMON_SSH
     /**
-     * Whether SFTP should be enabled for the VNC connection.
+     * Whether SFTP should be enabled for the RDP connection.
      */
     int enable_sftp;
 
@@ -450,6 +460,16 @@ typedef struct guac_rdp_settings {
      * cases.
      */
     int sftp_server_alive_interval;
+    
+    /**
+     * Whether or not to disable file download over SFTP.
+     */
+    int sftp_disable_download;
+    
+    /**
+     * Whether or not to disable file upload over SFTP.
+     */
+    int sftp_disable_upload;
 #endif
 
     /**
@@ -545,6 +565,29 @@ typedef struct guac_rdp_settings {
      * the connection broker, if a connection broker is being used.
      */
     char* load_balance_info;
+    
+    /**
+     * Whether or not to send a magic WoL packet to wake up the host before
+     * trying to connect.  Zero will disable sending the packet, non-zero
+     * values will trigger sending the packet.
+     */
+    int wol_send_packet;
+    
+    /**
+     * The mac address to put in the magic WoL packet.
+     */
+    char* wol_mac_addr;
+    
+    /**
+     * The broadcast address to send the magic WoL packet to.
+     */
+    char* wol_broadcast_addr;
+    
+    /**
+     * The amount of time to wait after sending the magic WoL packet before
+     * continuing the connection.
+     */
+    int wol_wait_time;
 
 } guac_rdp_settings;
 

--- a/src/protocols/rdp/upload.c
+++ b/src/protocols/rdp/upload.c
@@ -87,6 +87,18 @@ int guac_rdp_upload_file_handler(guac_user* user, guac_stream* stream,
         return 0;
     }
 
+    /* Ignore upload if uploads have been disabled */
+    if (fs->disable_upload) {
+        guac_client_log(client, GUAC_LOG_WARNING, "A upload attempt has "
+                "been blocked due to uploads being disabled, however it "
+                "should have been blocked at a higher level. This is likely "
+                "a bug.");
+        guac_protocol_send_ack(user->socket, stream, "FAIL (UPLOAD DISABLED)",
+                GUAC_PROTOCOL_STATUS_CLIENT_FORBIDDEN);
+        guac_socket_flush(user->socket);
+        return 0;
+    }
+
     /* Translate name */
     __generate_upload_path(filename, file_path);
 
@@ -201,6 +213,18 @@ int guac_rdp_upload_put_handler(guac_user* user, guac_object* object,
     if (fs == NULL) {
         guac_protocol_send_ack(user->socket, stream, "FAIL (NO FS)",
                 GUAC_PROTOCOL_STATUS_SERVER_ERROR);
+        guac_socket_flush(user->socket);
+        return 0;
+    }
+
+    /* Ignore upload if uploads have been disabled */
+    if (fs->disable_upload) {
+        guac_client_log(client, GUAC_LOG_WARNING, "A upload attempt has "
+                "been blocked due to uploads being disabled, however it "
+                "should have been blocked at a higher level. This is likely "
+                "a bug.");
+        guac_protocol_send_ack(user->socket, stream, "FAIL (UPLOAD DISABLED)",
+                GUAC_PROTOCOL_STATUS_CLIENT_FORBIDDEN);
         guac_socket_flush(user->socket);
         return 0;
     }

--- a/src/protocols/ssh/argv.c
+++ b/src/protocols/ssh/argv.c
@@ -30,127 +30,27 @@
 #include <stdlib.h>
 #include <string.h>
 
-/**
- * All SSH connection settings which may be updated by unprivileged users
- * through "argv" streams.
- */
-typedef enum guac_ssh_argv_setting {
-
-    /**
-     * The color scheme of the terminal.
-     */
-    GUAC_SSH_ARGV_SETTING_COLOR_SCHEME,
-
-    /**
-     * The name of the font family used by the terminal.
-     */
-    GUAC_SSH_ARGV_SETTING_FONT_NAME,
-
-    /**
-     * The size of the font used by the terminal, in points.
-     */
-    GUAC_SSH_ARGV_SETTING_FONT_SIZE
-
-} guac_ssh_argv_setting;
-
-/**
- * The value or current status of a connection parameter received over an
- * "argv" stream.
- */
-typedef struct guac_ssh_argv {
-
-    /**
-     * The specific setting being updated.
-     */
-    guac_ssh_argv_setting setting;
-
-    /**
-     * Buffer space for containing the received argument value.
-     */
-    char buffer[GUAC_SSH_ARGV_MAX_LENGTH];
-
-    /**
-     * The number of bytes received so far.
-     */
-    int length;
-
-} guac_ssh_argv;
-
-/**
- * Handler for "blob" instructions which appends the data from received blobs
- * to the end of the in-progress argument value buffer.
- *
- * @see guac_user_blob_handler
- */
-static int guac_ssh_argv_blob_handler(guac_user* user,
-        guac_stream* stream, void* data, int length) {
-
-    guac_ssh_argv* argv = (guac_ssh_argv*) stream->data;
-
-    /* Calculate buffer size remaining, including space for null terminator,
-     * adjusting received length accordingly */
-    int remaining = sizeof(argv->buffer) - argv->length - 1;
-    if (length > remaining)
-        length = remaining;
-
-    /* Append received data to end of buffer */
-    memcpy(argv->buffer + argv->length, data, length);
-    argv->length += length;
-
-    return 0;
-
-}
-
-/**
- * Handler for "end" instructions which applies the changes specified by the
- * argument value buffer associated with the stream.
- *
- * @see guac_user_end_handler
- */
-static int guac_ssh_argv_end_handler(guac_user* user,
-        guac_stream* stream) {
-
-    int size;
+int guac_ssh_argv_callback(guac_user* user, const char* mimetype,
+        const char* name, const char* value, void* data) {
 
     guac_client* client = user->client;
     guac_ssh_client* ssh_client = (guac_ssh_client*) client->data;
     guac_terminal* terminal = ssh_client->term;
 
-    /* Append null terminator to value */
-    guac_ssh_argv* argv = (guac_ssh_argv*) stream->data;
-    argv->buffer[argv->length] = '\0';
+    /* Update color scheme */
+    if (strcmp(name, GUAC_SSH_ARGV_COLOR_SCHEME) == 0)
+        guac_terminal_apply_color_scheme(terminal, value);
 
-    /* Apply changes to chosen setting */
-    switch (argv->setting) {
+    /* Update font name */
+    else if (strcmp(name, GUAC_SSH_ARGV_FONT_NAME) == 0)
+        guac_terminal_apply_font(terminal, value, -1, 0);
 
-        /* Update color scheme */
-        case GUAC_SSH_ARGV_SETTING_COLOR_SCHEME:
-            guac_terminal_apply_color_scheme(terminal, argv->buffer);
-            guac_client_stream_argv(client, client->socket, "text/plain",
-                    "color-scheme", argv->buffer);
-            break;
-
-        /* Update font name */
-        case GUAC_SSH_ARGV_SETTING_FONT_NAME:
-            guac_terminal_apply_font(terminal, argv->buffer, -1, 0);
-            guac_client_stream_argv(client, client->socket, "text/plain",
-                    "font-name", argv->buffer);
-            break;
-
-        /* Update font size */
-        case GUAC_SSH_ARGV_SETTING_FONT_SIZE:
-
-            /* Update only if font size is sane */
-            size = atoi(argv->buffer);
-            if (size > 0) {
-                guac_terminal_apply_font(terminal, NULL, size,
-                        ssh_client->settings->resolution);
-                guac_client_stream_argv(client, client->socket, "text/plain",
-                        "font-size", argv->buffer);
-            }
-
-            break;
-
+    /* Update only if font size is sane */
+    else if (strcmp(name, GUAC_SSH_ARGV_FONT_SIZE) == 0) {
+        int size = atoi(value);
+        if (size > 0)
+            guac_terminal_apply_font(terminal, NULL, size,
+                    ssh_client->settings->resolution);
     }
 
     /* Update SSH pty size if connected */
@@ -161,45 +61,6 @@ static int guac_ssh_argv_end_handler(guac_user* user,
         pthread_mutex_unlock(&(ssh_client->term_channel_lock));
     }
 
-    free(argv);
-    return 0;
-
-}
-
-int guac_ssh_argv_handler(guac_user* user, guac_stream* stream,
-        char* mimetype, char* name) {
-
-    guac_ssh_argv_setting setting;
-
-    /* Allow users to update the color scheme and font details */
-    if (strcmp(name, "color-scheme") == 0)
-        setting = GUAC_SSH_ARGV_SETTING_COLOR_SCHEME;
-    else if (strcmp(name, "font-name") == 0)
-        setting = GUAC_SSH_ARGV_SETTING_FONT_NAME;
-    else if (strcmp(name, "font-size") == 0)
-        setting = GUAC_SSH_ARGV_SETTING_FONT_SIZE;
-
-    /* No other connection parameters may be updated */
-    else {
-        guac_protocol_send_ack(user->socket, stream, "Not allowed.",
-                GUAC_PROTOCOL_STATUS_CLIENT_FORBIDDEN);
-        guac_socket_flush(user->socket);
-        return 0;
-    }
-
-    guac_ssh_argv* argv = malloc(sizeof(guac_ssh_argv));
-    argv->setting = setting;
-    argv->length = 0;
-
-    /* Prepare stream to receive argument value */
-    stream->blob_handler = guac_ssh_argv_blob_handler;
-    stream->end_handler = guac_ssh_argv_end_handler;
-    stream->data = argv;
-
-    /* Signal stream is ready */
-    guac_protocol_send_ack(user->socket, stream, "Ready for updated "
-            "parameter.", GUAC_PROTOCOL_STATUS_SUCCESS);
-    guac_socket_flush(user->socket);
     return 0;
 
 }
@@ -210,18 +71,18 @@ void* guac_ssh_send_current_argv(guac_user* user, void* data) {
     guac_terminal* terminal = ssh_client->term;
 
     /* Send current color scheme */
-    guac_user_stream_argv(user, user->socket, "text/plain", "color-scheme",
-            terminal->color_scheme);
+    guac_user_stream_argv(user, user->socket, "text/plain",
+            GUAC_SSH_ARGV_COLOR_SCHEME, terminal->color_scheme);
 
     /* Send current font name */
-    guac_user_stream_argv(user, user->socket, "text/plain", "font-name",
-            terminal->font_name);
+    guac_user_stream_argv(user, user->socket, "text/plain",
+            GUAC_SSH_ARGV_FONT_NAME, terminal->font_name);
 
     /* Send current font size */
     char font_size[64];
     sprintf(font_size, "%i", terminal->font_size);
-    guac_user_stream_argv(user, user->socket, "text/plain", "font-size",
-            font_size);
+    guac_user_stream_argv(user, user->socket, "text/plain",
+            GUAC_SSH_ARGV_FONT_SIZE, font_size);
 
     return NULL;
 

--- a/src/protocols/ssh/argv.h
+++ b/src/protocols/ssh/argv.h
@@ -23,19 +23,32 @@
 
 #include "config.h"
 
+#include <guacamole/argv.h>
 #include <guacamole/user.h>
 
 /**
- * The maximum number of bytes to allow for any argument value received via an
- * argv stream, including null terminator.
+ * The name of the parameter that specifies/updates the color scheme used by
+ * the terminal emulator.
  */
-#define GUAC_SSH_ARGV_MAX_LENGTH 16384
+#define GUAC_SSH_ARGV_COLOR_SCHEME "color-scheme"
 
 /**
- * Handles an incoming stream from a Guacamole "argv" instruction, updating the
- * given connection parameter if that parameter is allowed to be updated.
+ * The name of the parameter that specifies/updates the name of the font used
+ * by the terminal emulator.
  */
-guac_user_argv_handler guac_ssh_argv_handler;
+#define GUAC_SSH_ARGV_FONT_NAME "font-name"
+
+/**
+ * The name of the parameter that specifies/updates the font size used by the
+ * terminal emulator.
+ */
+#define GUAC_SSH_ARGV_FONT_SIZE "font-size"
+
+/**
+ * Handles a received argument value from a Guacamole "argv" instruction,
+ * updating the given connection parameter.
+ */
+guac_argv_callback guac_ssh_argv_callback;
 
 /**
  * Sends the current values of all non-sensitive parameters which may be set

--- a/src/protocols/ssh/client.c
+++ b/src/protocols/ssh/client.c
@@ -19,6 +19,7 @@
 
 #include "config.h"
 
+#include "argv.h"
 #include "client.h"
 #include "common/clipboard.h"
 #include "common/recording.h"
@@ -32,6 +33,7 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include <guacamole/argv.h>
 #include <guacamole/client.h>
 
 int guac_client_init(guac_client* client) {
@@ -49,6 +51,11 @@ int guac_client_init(guac_client* client) {
     /* Set handlers */
     client->join_handler = guac_ssh_user_join_handler;
     client->free_handler = guac_ssh_client_free_handler;
+
+    /* Register handlers for argument values that may be sent after the handshake */
+    guac_argv_register(GUAC_SSH_ARGV_COLOR_SCHEME, guac_ssh_argv_callback, NULL, GUAC_ARGV_OPTION_ECHO);
+    guac_argv_register(GUAC_SSH_ARGV_FONT_NAME, guac_ssh_argv_callback, NULL, GUAC_ARGV_OPTION_ECHO);
+    guac_argv_register(GUAC_SSH_ARGV_FONT_SIZE, guac_ssh_argv_callback, NULL, GUAC_ARGV_OPTION_ECHO);
 
     /* Set locale and warn if not UTF-8 */
     setlocale(LC_CTYPE, "");

--- a/src/protocols/ssh/settings.h
+++ b/src/protocols/ssh/settings.h
@@ -179,6 +179,20 @@ typedef struct guac_ssh_settings {
      * filesystem guac_object.
      */
     char* sftp_root_directory;
+    
+    /**
+     * Whether file download over SFTP should be disabled.  If set to true, file
+     * downloads will not be allowed over SFTP.  If not set or set to false, file
+     * downloads will be allowed.
+     */
+    bool sftp_disable_download;
+    
+    /**
+     * Whether file uploads over SFTP should be disabled.  If set to true, file
+     * uploads will not be allowed over SFTP.  If not set or set to false, file
+     * uploads will be allowed.
+     */
+    bool sftp_disable_upload;
 
 #ifdef ENABLE_SSH_AGENT
     /**
@@ -272,6 +286,26 @@ typedef struct guac_ssh_settings {
      * The client timezone to pass to the remote system.
      */
     char* timezone;
+    
+    /**
+     * Whether or not to send the Wake-on-LAN magic packet.
+     */
+    bool wol_send_packet;
+    
+    /**
+     * The MAC address to put in the magic WoL packet for the host to wake.
+     */
+    char* wol_mac_addr;
+    
+    /**
+     * The broadcast address to which to send the magic WoL packet.
+     */
+    char* wol_broadcast_addr;
+    
+    /**
+     * The amount of time to wait for the system to wake after sending the packet.
+     */
+    int wol_wait_time;
 
 } guac_ssh_settings;
 

--- a/src/protocols/ssh/user.c
+++ b/src/protocols/ssh/user.c
@@ -29,6 +29,7 @@
 #include "ssh.h"
 #include "settings.h"
 
+#include <guacamole/argv.h>
 #include <guacamole/client.h>
 #include <guacamole/socket.h>
 #include <guacamole/user.h>
@@ -93,13 +94,13 @@ int guac_ssh_user_join_handler(guac_user* user, int argc, char** argv) {
         user->pipe_handler = guac_ssh_pipe_handler;
 
         /* Updates to connection parameters */
-        user->argv_handler = guac_ssh_argv_handler;
+        user->argv_handler = guac_argv_handler;
 
         /* Display size change events */
         user->size_handler = guac_ssh_user_size_handler;
 
         /* Set generic (non-filesystem) file upload handler */
-        if (settings->enable_sftp)
+        if (settings->enable_sftp && !settings->sftp_disable_upload)
             user->file_handler = guac_sftp_file_handler;
 
     }

--- a/src/protocols/telnet/argv.c
+++ b/src/protocols/telnet/argv.c
@@ -29,127 +29,27 @@
 #include <stdlib.h>
 #include <string.h>
 
-/**
- * All telnet connection settings which may be updated by unprivileged users
- * through "argv" streams.
- */
-typedef enum guac_telnet_argv_setting {
-
-    /**
-     * The color scheme of the terminal.
-     */
-    GUAC_TELNET_ARGV_SETTING_COLOR_SCHEME,
-
-    /**
-     * The name of the font family used by the terminal.
-     */
-    GUAC_TELNET_ARGV_SETTING_FONT_NAME,
-
-    /**
-     * The size of the font used by the terminal, in points.
-     */
-    GUAC_TELNET_ARGV_SETTING_FONT_SIZE
-
-} guac_telnet_argv_setting;
-
-/**
- * The value or current status of a connection parameter received over an
- * "argv" stream.
- */
-typedef struct guac_telnet_argv {
-
-    /**
-     * The specific setting being updated.
-     */
-    guac_telnet_argv_setting setting;
-
-    /**
-     * Buffer space for containing the received argument value.
-     */
-    char buffer[GUAC_TELNET_ARGV_MAX_LENGTH];
-
-    /**
-     * The number of bytes received so far.
-     */
-    int length;
-
-} guac_telnet_argv;
-
-/**
- * Handler for "blob" instructions which appends the data from received blobs
- * to the end of the in-progress argument value buffer.
- *
- * @see guac_user_blob_handler
- */
-static int guac_telnet_argv_blob_handler(guac_user* user,
-        guac_stream* stream, void* data, int length) {
-
-    guac_telnet_argv* argv = (guac_telnet_argv*) stream->data;
-
-    /* Calculate buffer size remaining, including space for null terminator,
-     * adjusting received length accordingly */
-    int remaining = sizeof(argv->buffer) - argv->length - 1;
-    if (length > remaining)
-        length = remaining;
-
-    /* Append received data to end of buffer */
-    memcpy(argv->buffer + argv->length, data, length);
-    argv->length += length;
-
-    return 0;
-
-}
-
-/**
- * Handler for "end" instructions which applies the changes specified by the
- * argument value buffer associated with the stream.
- *
- * @see guac_user_end_handler
- */
-static int guac_telnet_argv_end_handler(guac_user* user,
-        guac_stream* stream) {
-
-    int size;
+int guac_telnet_argv_callback(guac_user* user, const char* mimetype,
+        const char* name, const char* value, void* data) {
 
     guac_client* client = user->client;
     guac_telnet_client* telnet_client = (guac_telnet_client*) client->data;
     guac_terminal* terminal = telnet_client->term;
 
-    /* Append null terminator to value */
-    guac_telnet_argv* argv = (guac_telnet_argv*) stream->data;
-    argv->buffer[argv->length] = '\0';
+    /* Update color scheme */
+    if (strcmp(name, GUAC_TELNET_ARGV_COLOR_SCHEME) == 0)
+        guac_terminal_apply_color_scheme(terminal, value);
 
-    /* Apply changes to chosen setting */
-    switch (argv->setting) {
+    /* Update font name */
+    else if (strcmp(name, GUAC_TELNET_ARGV_FONT_NAME) == 0)
+        guac_terminal_apply_font(terminal, value, -1, 0);
 
-        /* Update color scheme */
-        case GUAC_TELNET_ARGV_SETTING_COLOR_SCHEME:
-            guac_terminal_apply_color_scheme(terminal, argv->buffer);
-            guac_client_stream_argv(client, client->socket, "text/plain",
-                    "color-scheme", argv->buffer);
-            break;
-
-        /* Update font name */
-        case GUAC_TELNET_ARGV_SETTING_FONT_NAME:
-            guac_terminal_apply_font(terminal, argv->buffer, -1, 0);
-            guac_client_stream_argv(client, client->socket, "text/plain",
-                    "font-name", argv->buffer);
-            break;
-
-        /* Update font size */
-        case GUAC_TELNET_ARGV_SETTING_FONT_SIZE:
-
-            /* Update only if font size is sane */
-            size = atoi(argv->buffer);
-            if (size > 0) {
-                guac_terminal_apply_font(terminal, NULL, size,
-                        telnet_client->settings->resolution);
-                guac_client_stream_argv(client, client->socket, "text/plain",
-                        "font-size", argv->buffer);
-            }
-
-            break;
-
+    /* Update only if font size is sane */
+    else if (strcmp(name, GUAC_TELNET_ARGV_FONT_SIZE) == 0) {
+        int size = atoi(value);
+        if (size > 0)
+            guac_terminal_apply_font(terminal, NULL, size,
+                    telnet_client->settings->resolution);
     }
 
     /* Update terminal window size if connected */
@@ -157,45 +57,6 @@ static int guac_telnet_argv_end_handler(guac_user* user,
         guac_telnet_send_naws(telnet_client->telnet, terminal->term_width,
                 terminal->term_height);
 
-    free(argv);
-    return 0;
-
-}
-
-int guac_telnet_argv_handler(guac_user* user, guac_stream* stream,
-        char* mimetype, char* name) {
-
-    guac_telnet_argv_setting setting;
-
-    /* Allow users to update the color scheme and font details */
-    if (strcmp(name, "color-scheme") == 0)
-        setting = GUAC_TELNET_ARGV_SETTING_COLOR_SCHEME;
-    else if (strcmp(name, "font-name") == 0)
-        setting = GUAC_TELNET_ARGV_SETTING_FONT_NAME;
-    else if (strcmp(name, "font-size") == 0)
-        setting = GUAC_TELNET_ARGV_SETTING_FONT_SIZE;
-
-    /* No other connection parameters may be updated */
-    else {
-        guac_protocol_send_ack(user->socket, stream, "Not allowed.",
-                GUAC_PROTOCOL_STATUS_CLIENT_FORBIDDEN);
-        guac_socket_flush(user->socket);
-        return 0;
-    }
-
-    guac_telnet_argv* argv = malloc(sizeof(guac_telnet_argv));
-    argv->setting = setting;
-    argv->length = 0;
-
-    /* Prepare stream to receive argument value */
-    stream->blob_handler = guac_telnet_argv_blob_handler;
-    stream->end_handler = guac_telnet_argv_end_handler;
-    stream->data = argv;
-
-    /* Signal stream is ready */
-    guac_protocol_send_ack(user->socket, stream, "Ready for updated "
-            "parameter.", GUAC_PROTOCOL_STATUS_SUCCESS);
-    guac_socket_flush(user->socket);
     return 0;
 
 }
@@ -206,18 +67,18 @@ void* guac_telnet_send_current_argv(guac_user* user, void* data) {
     guac_terminal* terminal = telnet_client->term;
 
     /* Send current color scheme */
-    guac_user_stream_argv(user, user->socket, "text/plain", "color-scheme",
-            terminal->color_scheme);
+    guac_user_stream_argv(user, user->socket, "text/plain",
+            GUAC_TELNET_ARGV_COLOR_SCHEME, terminal->color_scheme);
 
     /* Send current font name */
-    guac_user_stream_argv(user, user->socket, "text/plain", "font-name",
-            terminal->font_name);
+    guac_user_stream_argv(user, user->socket, "text/plain",
+            GUAC_TELNET_ARGV_FONT_NAME, terminal->font_name);
 
     /* Send current font size */
     char font_size[64];
     sprintf(font_size, "%i", terminal->font_size);
-    guac_user_stream_argv(user, user->socket, "text/plain", "font-size",
-            font_size);
+    guac_user_stream_argv(user, user->socket, "text/plain",
+            GUAC_TELNET_ARGV_FONT_SIZE, font_size);
 
     return NULL;
 

--- a/src/protocols/telnet/argv.h
+++ b/src/protocols/telnet/argv.h
@@ -23,19 +23,32 @@
 
 #include "config.h"
 
+#include <guacamole/argv.h>
 #include <guacamole/user.h>
 
 /**
- * The maximum number of bytes to allow for any argument value received via an
- * argv stream, including null terminator.
+ * The name of the parameter that specifies/updates the color scheme used by
+ * the terminal emulator.
  */
-#define GUAC_TELNET_ARGV_MAX_LENGTH 16384
+#define GUAC_TELNET_ARGV_COLOR_SCHEME "color-scheme"
 
 /**
- * Handles an incoming stream from a Guacamole "argv" instruction, updating the
- * given connection parameter if that parameter is allowed to be updated.
+ * The name of the parameter that specifies/updates the name of the font used
+ * by the terminal emulator.
  */
-guac_user_argv_handler guac_telnet_argv_handler;
+#define GUAC_TELNET_ARGV_FONT_NAME "font-name"
+
+/**
+ * The name of the parameter that specifies/updates the font size used by the
+ * terminal emulator.
+ */
+#define GUAC_TELNET_ARGV_FONT_SIZE "font-size"
+
+/**
+ * Handles a received argument value from a Guacamole "argv" instruction,
+ * updating the given connection parameter.
+ */
+guac_argv_callback guac_telnet_argv_callback;
 
 /**
  * Sends the current values of all non-sensitive parameters which may be set

--- a/src/protocols/telnet/client.c
+++ b/src/protocols/telnet/client.c
@@ -18,6 +18,7 @@
  */
 
 #include "config.h"
+#include "argv.h"
 #include "client.h"
 #include "common/recording.h"
 #include "settings.h"
@@ -31,6 +32,7 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include <guacamole/argv.h>
 #include <guacamole/client.h>
 
 int guac_client_init(guac_client* client) {
@@ -53,6 +55,11 @@ int guac_client_init(guac_client* client) {
     /* Set handlers */
     client->join_handler = guac_telnet_user_join_handler;
     client->free_handler = guac_telnet_client_free_handler;
+
+    /* Register handlers for argument values that may be sent after the handshake */
+    guac_argv_register(GUAC_TELNET_ARGV_COLOR_SCHEME, guac_telnet_argv_callback, NULL, GUAC_ARGV_OPTION_ECHO);
+    guac_argv_register(GUAC_TELNET_ARGV_FONT_NAME, guac_telnet_argv_callback, NULL, GUAC_ARGV_OPTION_ECHO);
+    guac_argv_register(GUAC_TELNET_ARGV_FONT_SIZE, guac_telnet_argv_callback, NULL, GUAC_ARGV_OPTION_ECHO);
 
     /* Set locale and warn if not UTF-8 */
     setlocale(LC_CTYPE, "");

--- a/src/protocols/telnet/settings.h
+++ b/src/protocols/telnet/settings.h
@@ -256,6 +256,30 @@ typedef struct guac_telnet_settings {
      * The terminal emulator type that is passed to the remote system.
      */
     char* terminal_type;
+    
+    /**
+     * Whether or not to send the magic Wake-on-LAN (WoL) packet prior to
+     * continuing the connection.
+     */
+    bool wol_send_packet;
+    
+    /**
+     * The MAC address to put in the magic WoL packet for the remote host to
+     * wake.
+     */
+    char* wol_mac_addr;
+    
+    /**
+     * The broadcast address to which to send the magic WoL packet to wake
+     * the remote host.
+     */
+    char* wol_broadcast_addr;
+    
+    /**
+     * The number of seconds to wait after sending the magic WoL packet before
+     * continuing the connection.
+     */
+    int wol_wait_time;
 
 } guac_telnet_settings;
 

--- a/src/protocols/telnet/user.c
+++ b/src/protocols/telnet/user.c
@@ -92,7 +92,7 @@ int guac_telnet_user_join_handler(guac_user* user, int argc, char** argv) {
         user->pipe_handler = guac_telnet_pipe_handler;
 
         /* Updates to connection parameters */
-        user->argv_handler = guac_telnet_argv_handler;
+        user->argv_handler = guac_argv_handler;
 
         /* Display size change events */
         user->size_handler = guac_telnet_user_size_handler;

--- a/src/protocols/vnc/Makefile.am
+++ b/src/protocols/vnc/Makefile.am
@@ -29,6 +29,7 @@ ACLOCAL_AMFLAGS = -I m4
 lib_LTLIBRARIES = libguac-client-vnc.la
 
 libguac_client_vnc_la_SOURCES = \
+    argv.c                      \
     auth.c                      \
     client.c                    \
     clipboard.c                 \
@@ -41,6 +42,7 @@ libguac_client_vnc_la_SOURCES = \
     vnc.c
     
 noinst_HEADERS =      \
+    argv.h            \
     auth.h            \
     client.h          \
     clipboard.h       \

--- a/src/protocols/vnc/argv.c
+++ b/src/protocols/vnc/argv.c
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "config.h"
+#include "argv.h"
+#include "vnc.h"
+
+#include <guacamole/protocol.h>
+#include <guacamole/socket.h>
+#include <guacamole/user.h>
+
+#include <pthread.h>
+#include <stdlib.h>
+#include <string.h>
+
+int guac_vnc_argv_callback(guac_user* user, const char* mimetype,
+        const char* name, const char* value, void* data) {
+
+    guac_client* client = user->client;
+    guac_vnc_client* vnc_client = (guac_vnc_client*) client->data;
+    guac_vnc_settings* settings = vnc_client->settings;
+
+    /* Update username */
+    if (strcmp(name, GUAC_VNC_ARGV_USERNAME) == 0) {
+        free(settings->username);
+        settings->username = strdup(value);
+    }
+    
+    /* Update password */
+    else if (strcmp(name, GUAC_VNC_ARGV_PASSWORD) == 0) {
+        free(settings->password);
+        settings->password = strdup(value);
+    }
+
+    return 0;
+
+}

--- a/src/protocols/vnc/argv.h
+++ b/src/protocols/vnc/argv.h
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef ARGV_H
+#define ARGV_H
+
+#include "config.h"
+
+#include <guacamole/argv.h>
+#include <guacamole/user.h>
+
+/**
+ * Handles a received argument value from a Guacamole "argv" instruction,
+ * updating the given connection parameter.
+ */
+guac_argv_callback guac_vnc_argv_callback;
+
+/**
+ * The name of the parameter Guacamole will use to specify/update the username
+ * for the VNC connection.
+ */
+#define GUAC_VNC_ARGV_USERNAME "username"
+
+/**
+ * The name of the parameter Guacamole will use to specify/update the password
+ * for the VNC connection.
+ */
+#define GUAC_VNC_ARGV_PASSWORD "password"
+
+#endif /* ARGV_H */
+

--- a/src/protocols/vnc/auth.c
+++ b/src/protocols/vnc/auth.c
@@ -19,15 +19,101 @@
 
 #include "config.h"
 
+#include "argv.h"
 #include "auth.h"
 #include "vnc.h"
 
+#include <guacamole/argv.h>
 #include <guacamole/client.h>
+#include <guacamole/protocol.h>
+#include <guacamole/socket.h>
+#include <guacamole/string.h>
 #include <rfb/rfbclient.h>
 #include <rfb/rfbproto.h>
 
+#include <pthread.h>
+#include <string.h>
+
 char* guac_vnc_get_password(rfbClient* client) {
     guac_client* gc = rfbClientGetClientData(client, GUAC_VNC_CLIENT_KEY);
-    return ((guac_vnc_client*) gc->data)->settings->password;
+    guac_vnc_client* vnc_client = ((guac_vnc_client*) gc->data);
+    guac_vnc_settings* settings = vnc_client->settings;
+    
+    /* If the client does not support the "required" instruction, just return
+        the configuration data. */
+    if (!guac_client_owner_supports_required(gc))
+        return guac_strdup(settings->password);
+    
+    /* If password isn't around, prompt for it. */
+    if (settings->password == NULL) {
+        
+        guac_argv_register(GUAC_VNC_ARGV_PASSWORD, guac_vnc_argv_callback, NULL, 0);
+        
+        const char* params[] = {GUAC_VNC_ARGV_PASSWORD, NULL};
+        
+        /* Send the request for password to the owner. */
+        guac_client_owner_send_required(gc, params);
+                
+        /* Wait for the arguments to be returned */
+        guac_argv_await(params);
+
+    }
+    
+    return guac_strdup(settings->password);
+    
 }
 
+rfbCredential* guac_vnc_get_credentials(rfbClient* client, int credentialType) {
+    
+    guac_client* gc = rfbClientGetClientData(client, GUAC_VNC_CLIENT_KEY);
+    guac_vnc_client* vnc_client = ((guac_vnc_client*) gc->data);
+    guac_vnc_settings* settings = vnc_client->settings;
+    
+    /* Handle request for Username/Password credentials */
+    if (credentialType == rfbCredentialTypeUser) {
+        rfbCredential *creds = malloc(sizeof(rfbCredential));
+        
+        /* If the client supports the "required" instruction, prompt for and
+           update those. */
+        if (guac_client_owner_supports_required(gc)) {
+            char* params[3] = {NULL};
+            int i = 0;
+
+            /* Check if username is not provided. */
+            if (settings->username == NULL) {
+                guac_argv_register(GUAC_VNC_ARGV_USERNAME, guac_vnc_argv_callback, NULL, 0);
+                params[i] = GUAC_VNC_ARGV_USERNAME;
+                i++;
+            }
+
+            /* Check if password is not provided. */
+            if (settings->password == NULL) {
+                guac_argv_register(GUAC_VNC_ARGV_PASSWORD, guac_vnc_argv_callback, NULL, 0);
+                params[i] = GUAC_VNC_ARGV_PASSWORD;
+                i++;
+            }
+
+            params[i] = NULL;
+
+            /* If we have empty parameters, request them and await response. */
+            if (i > 0) {
+                guac_client_owner_send_required(gc, (const char**) params);
+                guac_argv_await((const char**) params);
+            }
+        }
+        
+        /* Copy the values and return the credential set. */
+        creds->userCredential.username = guac_strdup(settings->username);
+        creds->userCredential.password = guac_strdup(settings->password);
+        return creds;
+        
+    }
+
+    guac_client_abort(gc, GUAC_PROTOCOL_STATUS_SERVER_ERROR,
+            "Unsupported credential type requested.");
+    guac_client_log(gc, GUAC_LOG_DEBUG,
+            "Unable to provide requested type of credential: %d.",
+            credentialType);
+    return NULL;
+    
+}

--- a/src/protocols/vnc/auth.h
+++ b/src/protocols/vnc/auth.h
@@ -27,7 +27,7 @@
 
 /**
  * Callback which is invoked by libVNCServer when it needs to read the user's
- * VNC password. As ths user's password, if any, will be stored in the
+ * VNC password. As this user's password, if any, will be stored in the
  * connection settings, this function does nothing more than return that value.
  *
  * @param client
@@ -37,6 +37,24 @@
  *     The password to provide to the VNC server.
  */
 char* guac_vnc_get_password(rfbClient* client);
+
+/**
+ * Callback which is invoked by libVNCServer when it needs to read the user's
+ * VNC credentials.  The credentials are stored in the connection settings,
+ * so they will be retrieved from that.
+ * 
+ * @param client
+ *     The rfbClient associated with the VNC connection requiring the
+ *     authentication.
+ * 
+ * @param credentialType
+ *     The credential type being requested, as defined by the libVNCclient
+ *     code in the rfbclient.h header.
+ * 
+ * @return
+ *     The rfbCredential object that contains the required credentials.
+ */
+rfbCredential* guac_vnc_get_credentials(rfbClient* client, int credentialType);
 
 #endif
 

--- a/src/protocols/vnc/client.c
+++ b/src/protocols/vnc/client.c
@@ -36,6 +36,7 @@
 
 #include <guacamole/client.h>
 
+#include <pthread.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -47,6 +48,11 @@ int guac_client_init(guac_client* client) {
     /* Alloc client data */
     guac_vnc_client* vnc_client = calloc(1, sizeof(guac_vnc_client));
     client->data = vnc_client;
+
+#ifdef ENABLE_VNC_TLS_LOCKING
+    /* Initialize the TLS write lock */
+    pthread_mutex_init(&vnc_client->tls_lock, NULL);
+#endif
 
     /* Init clipboard */
     vnc_client->clipboard = guac_common_clipboard_alloc(GUAC_VNC_CLIPBOARD_MAX_LENGTH);
@@ -124,6 +130,11 @@ int guac_vnc_client_free_handler(guac_client* client) {
     /* Free parsed settings */
     if (settings != NULL)
         guac_vnc_settings_free(settings);
+
+#ifdef ENABLE_VNC_TLS_LOCKING
+    /* Clean up TLS lock mutex. */
+    pthread_mutex_destroy(&(vnc_client->tls_lock));
+#endif
 
     /* Free generic data struct */
     free(client->data);

--- a/src/protocols/vnc/settings.h
+++ b/src/protocols/vnc/settings.h
@@ -46,6 +46,11 @@ typedef struct guac_vnc_settings {
     int port;
 
     /**
+     * The username given in the arguments.
+     */
+    char* username;
+    
+    /**
      * The password given in the arguments.
      */
     char* password;
@@ -206,6 +211,20 @@ typedef struct guac_vnc_settings {
      * cases.
      */
     int sftp_server_alive_interval;
+    
+    /**
+     * Whether file downloads over SFTP should be blocked.  If set to "true",
+     * the local client will not be able to download files from the SFTP server.
+     * If set to "false" or not set, file downloads will be allowed.
+     */
+    bool sftp_disable_download;
+    
+    /**
+     * Whether file uploads over SFTP should be blocked.  If set to "true", the
+     * local client will not be able to upload files to the SFTP server.  If set
+     * to "false" or not set, file uploads will be allowed.
+     */
+    bool sftp_disable_upload;
 #endif
 
     /**
@@ -250,6 +269,31 @@ typedef struct guac_vnc_settings {
      * as passwords, credit card numbers, etc.
      */
     bool recording_include_keys;
+    
+    /**
+     * Whether or not to send the magic Wake-on-LAN (WoL) packet prior to
+     * trying to connect to the remote host.  By default this will not be sent.
+     * If this option is enabled but a MAC address is not provided a warning will
+     * be logged and the packet will not be sent.
+     */
+    bool wol_send_packet;
+    
+    /**
+     * The MAC address to place in the magic WoL packet to wake the remote host.
+     */
+    char* wol_mac_addr;
+    
+    /**
+     * The broadcast address to which to send the magic WoL packet to wake
+     * the remote host.
+     */
+    char* wol_broadcast_addr;
+    
+    /**
+     * The number of seconds after sending the magic WoL packet to wait before
+     * attempting to connect to the remote host.
+     */
+    int wol_wait_time;
 
 } guac_vnc_settings;
 

--- a/src/protocols/vnc/user.c
+++ b/src/protocols/vnc/user.c
@@ -32,6 +32,7 @@
 #include "pulse/pulse.h"
 #endif
 
+#include <guacamole/argv.h>
 #include <guacamole/audio.h>
 #include <guacamole/client.h>
 #include <guacamole/socket.h>
@@ -98,10 +99,14 @@ int guac_vnc_user_join_handler(guac_user* user, int argc, char** argv) {
         /* Inbound (client to server) clipboard transfer */
         if (!settings->disable_paste)
             user->clipboard_handler = guac_vnc_clipboard_handler;
+        
+        /* Updates to connection parameters if we own the connection */
+        if (user->owner)
+            user->argv_handler = guac_argv_handler;
 
 #ifdef ENABLE_COMMON_SSH
         /* Set generic (non-filesystem) file upload handler */
-        if (settings->enable_sftp)
+        if (settings->enable_sftp && !settings->sftp_disable_upload)
             user->file_handler = guac_vnc_sftp_file_handler;
 #endif
 

--- a/src/protocols/vnc/vnc.h
+++ b/src/protocols/vnc/vnc.h
@@ -55,6 +55,13 @@ typedef struct guac_vnc_client {
      */
     pthread_t client_thread;
 
+#ifdef ENABLE_VNC_TLS_LOCKING
+    /**
+     * The TLS mutex lock for the client.
+     */
+    pthread_mutex_t tls_lock;
+#endif
+
     /**
      * The underlying VNC client.
      */

--- a/src/terminal/terminal/terminal.h
+++ b/src/terminal/terminal/terminal.h
@@ -338,12 +338,19 @@ struct guac_terminal {
     int cursor_col;
 
     /**
+     * The desired visibility state of the cursor.
+     */
+    bool cursor_visible;
+
+    /**
      * The row of the rendered cursor.
+     * Will be set to -1 if the cursor is not visible.
      */
     int visible_cursor_row;
 
     /**
      * The column of the rendered cursor.
+     * Will be set to -1 if the cursor is not visible.
      */
     int visible_cursor_col;
 

--- a/src/terminal/terminal_handlers.c
+++ b/src/terminal/terminal_handlers.c
@@ -432,6 +432,7 @@ static bool* __guac_terminal_get_flag(guac_terminal* term, int num, char private
     if (private_mode == '?') {
         switch (num) {
             case 1:  return &(term->application_cursor_keys); /* DECCKM */
+            case 25: return &(term->cursor_visible); /* DECTECM */
         }
     }
 


### PR DESCRIPTION
These changes merge absolutely everything from the current upstream `staging/1.3.0` branch, bringing the guacamole-server portion of the GLEN 2.x source tree up-to-date with the latest changes pending upstream release.

Naturally, this changeset is huge. I've intentionally kept things isolated to a single merge commit which establishes what exactly has been merged (upstream commit 7fcddef1176811946deed6e9f2ab1f8d0b52c8b3). **Comparing the source tree against that commit, the only differences should be version number suffixes**.