### PR TITLE
GLEN-259: Merge changes from first RC for 1.3.0.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,13 +21,30 @@
 # Dockerfile for guacamole-server
 #
 
+# The Debian image that should be used as the basis for the guacd image
+ARG DEBIAN_BASE_IMAGE=buster-slim
 
 # Use Debian as base for the build
-ARG DEBIAN_VERSION=stable
-FROM debian:${DEBIAN_VERSION} AS builder
+FROM debian:${DEBIAN_BASE_IMAGE} AS builder
 
+#
+# The Debian repository that should be preferred for dependencies (this will be
+# added to /etc/apt/sources.list if not already present)
+#
+# NOTE: Due to limitations of the Docker image build process, this value is
+# duplicated in an ARG in the second stage of the build.
+#
+ARG DEBIAN_RELEASE=buster-backports
+
+# Add repository for specified Debian release if not already present in
+# sources.list
+RUN grep " ${DEBIAN_RELEASE} " /etc/apt/sources.list || echo >> /etc/apt/sources.list \
+    "deb http://deb.debian.org/debian ${DEBIAN_RELEASE} main contrib non-free"
+
+#
 # Base directory for installed build artifacts.
-# Due to limitations of the Docker image build process, this value is
+#
+# NOTE: Due to limitations of the Docker image build process, this value is
 # duplicated in an ARG in the second stage of the build.
 #
 ARG PREFIX_DIR=/usr/local/guacamole
@@ -53,9 +70,12 @@ ARG BUILD_DEPENDENCIES="              \
         libwebp-dev                   \
         make"
 
+# Do not require interaction during build
+ARG DEBIAN_FRONTEND=noninteractive
+
 # Bring build environment up to date and install build dependencies
-RUN apt-get update                         && \
-    apt-get install -y $BUILD_DEPENDENCIES && \
+RUN apt-get update                                              && \
+    apt-get install -t ${DEBIAN_RELEASE} -y $BUILD_DEPENDENCIES && \
     rm -rf /var/lib/apt/lists/*
 
 # Add configuration scripts
@@ -68,19 +88,35 @@ COPY . "$BUILD_DIR"
 RUN ${PREFIX_DIR}/bin/build-guacd.sh "$BUILD_DIR" "$PREFIX_DIR"
 
 # Record the packages of all runtime library dependencies
-RUN ${PREFIX_DIR}/bin/list-dependencies.sh    \
-        ${PREFIX_DIR}/sbin/guacd              \
-        ${PREFIX_DIR}/lib/libguac-client-*.so \
-        ${PREFIX_DIR}/lib/freerdp2/guac*.so   \
+RUN ${PREFIX_DIR}/bin/list-dependencies.sh     \
+        ${PREFIX_DIR}/sbin/guacd               \
+        ${PREFIX_DIR}/lib/libguac-client-*.so  \
+        ${PREFIX_DIR}/lib/freerdp2/*guac*.so   \
         > ${PREFIX_DIR}/DEPENDENCIES
 
 # Use same Debian as the base for the runtime image
-FROM debian:${DEBIAN_VERSION}-slim
+FROM debian:${DEBIAN_BASE_IMAGE}
 
-# Base directory for installed build artifacts.
-# Due to limitations of the Docker image build process, this value is
-# duplicated in an ARG in the first stage of the build. See also the
+#
+# The Debian repository that should be preferred for dependencies (this will be
+# added to /etc/apt/sources.list if not already present)
+#
+# NOTE: Due to limitations of the Docker image build process, this value is
+# duplicated in an ARG in the first stage of the build.
+#
+ARG DEBIAN_RELEASE=buster-backports
+
+# Add repository for specified Debian release if not already present in
+# sources.list
+RUN grep " ${DEBIAN_RELEASE} " /etc/apt/sources.list || echo >> /etc/apt/sources.list \
+    "deb http://deb.debian.org/debian ${DEBIAN_RELEASE} main contrib non-free"
+
+#
+# Base directory for installed build artifacts. See also the
 # CMD directive at the end of this build stage.
+#
+# NOTE: Due to limitations of the Docker image build process, this value is
+# duplicated in an ARG in the first stage of the build.
 #
 ARG PREFIX_DIR=/usr/local/guacamole
 
@@ -97,13 +133,16 @@ ARG RUNTIME_DEPENDENCIES="            \
         fonts-dejavu                  \
         xfonts-terminus"
 
+# Do not require interaction during build
+ARG DEBIAN_FRONTEND=noninteractive
+
 # Copy build artifacts into this stage
 COPY --from=builder ${PREFIX_DIR} ${PREFIX_DIR}
 
 # Bring runtime environment up to date and install runtime dependencies
-RUN apt-get update                                                                  && \
-    apt-get install -y --no-install-recommends $RUNTIME_DEPENDENCIES                && \
-    apt-get install -y --no-install-recommends $(cat "${PREFIX_DIR}"/DEPENDENCIES)  && \
+RUN apt-get update                                                                                       && \
+    apt-get install -t ${DEBIAN_RELEASE} -y --no-install-recommends $RUNTIME_DEPENDENCIES                && \
+    apt-get install -t ${DEBIAN_RELEASE} -y --no-install-recommends $(cat "${PREFIX_DIR}"/DEPENDENCIES)  && \
     rm -rf /var/lib/apt/lists/*
 
 # Link FreeRDP plugins into proper path
@@ -115,7 +154,9 @@ HEALTHCHECK --interval=5m --timeout=5s CMD nc -z 127.0.0.1 4822 || exit 1
 
 # Create a new user guacd
 ARG UID=1000
-RUN useradd --system --create-home --shell /usr/sbin/nologin --uid $UID --no-user-group guacd
+ARG GID=1000
+RUN groupadd --gid $GID guacd
+RUN useradd --system --create-home --shell /usr/sbin/nologin --uid $UID --gid $GID guacd
 
 # Run with user guacd
 USER guacd

--- a/configure.ac
+++ b/configure.ac
@@ -627,7 +627,13 @@ fi
 # between releases, as the change in behavior may not (yet) be associated with
 # a corresponding change in version number and may not have any detectable
 # effect on the FreeRDP API
-if test "x${have_freerdp2}" = "xyes"
+
+AC_ARG_ENABLE(allow_freerdp_snapshots,
+              [AS_HELP_STRING([--enable-allow-freerdp-snapshots],
+                              [allow building against unknown development snapshots of FreeRDP])
+              ],allow_freerdp_snapshots=yes)
+
+if test "x${have_freerdp2}" = "xyes" -a "x${allow_freerdp_snapshots}" != "xyes"
 then
 
     AC_MSG_CHECKING([whether FreeRDP appears to be a development version])
@@ -639,7 +645,7 @@ then
     ],
     [AC_MSG_RESULT([no])],
     [AC_MSG_RESULT([yes])]
-    [AC_MSG_WARN([
+    [AC_MSG_ERROR([
   --------------------------------------------
    You are building against a development version of FreeRDP. Non-release
    versions of FreeRDP may have differences in behavior that are impossible to
@@ -647,6 +653,9 @@ then
    behavior.
 
    *** PLEASE USE A RELEASED VERSION OF FREERDP IF POSSIBLE ***
+
+   If you are ABSOLUTELY CERTAIN that building against this version of FreeRDP
+   is OK, rerun configure with the --enable-allow-freerdp-snapshots
   --------------------------------------------])])
 
 fi

--- a/src/guacd/log.c
+++ b/src/guacd/log.c
@@ -133,7 +133,7 @@ void guacd_log_guac_error(guac_client_log_level level, const char* message) {
 void guacd_log_handshake_failure() {
 
     if (guac_error == GUAC_STATUS_CLOSED)
-        guacd_log(GUAC_LOG_INFO,
+        guacd_log(GUAC_LOG_DEBUG,
                 "Guacamole connection closed during handshake");
     else if (guac_error == GUAC_STATUS_PROTOCOL_ERROR)
         guacd_log(GUAC_LOG_ERROR,

--- a/src/libguac/user-handshake.c
+++ b/src/libguac/user-handshake.c
@@ -100,7 +100,7 @@ static void guac_user_log_guac_error(guac_user* user,
 static void guac_user_log_handshake_failure(guac_user* user) {
 
     if (guac_error == GUAC_STATUS_CLOSED)
-        guac_user_log(user, GUAC_LOG_INFO,
+        guac_user_log(user, GUAC_LOG_DEBUG,
                 "Guacamole connection closed during handshake");
     else if (guac_error == GUAC_STATUS_PROTOCOL_ERROR)
         guac_user_log(user, GUAC_LOG_ERROR,


### PR DESCRIPTION
As with #206 (from prior to the first RC), this change beings the Glyptodon source tree up-to-date with all changes for the pending upstream 1.3.0 release. Except for version numbers, the code here should be identical to 1.3.0-RC1, and should ultimately be identical to the 1.3.0 release unless there is an RC2.