### PR TITLE
GLEN-182: Backport support for OpenSSL 1.1.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -285,6 +285,51 @@ then
   --------------------------------------------])
     else
         AC_DEFINE([ENABLE_SSL],, [Whether SSL-related support is enabled])
+
+        # OpenSSL 1.1 accessor function for DSA signature values
+        AC_CHECK_DECL([DSA_SIG_get0],
+            [AC_DEFINE([HAVE_DSA_SIG_GET0],,
+                       [Whether libssl provides DSA_SIG_get0()])],,
+            [#include <openssl/dsa.h>])
+
+        # OpenSSL 1.1 accessor function for DSA public key parameters
+        AC_CHECK_DECL([DSA_get0_pqg],
+            [AC_DEFINE([HAVE_DSA_GET0_PQG],,
+                       [Whether libssl provides DSA_get0_pqg()])],,
+            [#include <openssl/dsa.h>])
+
+        # OpenSSL 1.1 accessor function for DSA public/private key values
+        AC_CHECK_DECL([DSA_get0_key],
+            [AC_DEFINE([HAVE_DSA_GET0_KEY],,
+                       [Whether libssl provides DSA_get0_key()])],,
+            [#include <openssl/dsa.h>])
+
+        # OpenSSL 1.1 accessor function for RSA public/private key values
+        AC_CHECK_DECL([RSA_get0_key],
+            [AC_DEFINE([HAVE_RSA_GET0_KEY],,
+                       [Whether libssl provides RSA_get0_key()])],,
+            [#include <openssl/rsa.h>])
+
+        # OpenSSL 1.1 does away with explicit threading callbacks
+        AC_MSG_CHECKING([whether libssl requires threading callbacks])
+        AC_COMPILE_IFELSE([AC_LANG_SOURCE([[
+
+            #include <openssl/opensslv.h>
+
+            #if OPENSSL_VERSION_NUMBER < 0x10100000L
+            #error Threading callbacks required.
+            #endif
+
+            int main() {
+                return 0;
+            }
+
+          ]])],
+          [AC_MSG_RESULT([no])],
+          [AC_MSG_RESULT([yes])
+           AC_DEFINE([OPENSSL_REQUIRES_THREADING_CALLBACKS],,
+                     [Whether OpenSSL requires explicit threading callbacks for threadsafety])])
+
     fi
 fi
 

--- a/src/common-ssh/Makefile.am
+++ b/src/common-ssh/Makefile.am
@@ -25,16 +25,20 @@ SUBDIRS = . tests
 
 libguac_common_ssh_la_SOURCES = \
     buffer.c                    \
+    dsa-compat.c                \
+    rsa-compat.c                \
     sftp.c                      \
     ssh.c                       \
     key.c                       \
     user.c
 
-noinst_HEADERS =        \
-    common-ssh/buffer.h \
-    common-ssh/key.h    \
-    common-ssh/sftp.h   \
-    common-ssh/ssh.h    \
+noinst_HEADERS =            \
+    common-ssh/buffer.h     \
+    common-ssh/dsa-compat.h \
+    common-ssh/rsa-compat.h \
+    common-ssh/key.h        \
+    common-ssh/sftp.h       \
+    common-ssh/ssh.h        \
     common-ssh/user.h
 
 libguac_common_ssh_la_CFLAGS = \

--- a/src/common-ssh/buffer.c
+++ b/src/common-ssh/buffer.c
@@ -54,7 +54,7 @@ void guac_common_ssh_buffer_write_data(char** buffer, const char* data,
     *buffer += length;
 }
 
-void guac_common_ssh_buffer_write_bignum(char** buffer, BIGNUM* value) {
+void guac_common_ssh_buffer_write_bignum(char** buffer, const BIGNUM* value) {
 
     unsigned char* bn_buffer;
     int length;

--- a/src/common-ssh/common-ssh/buffer.h
+++ b/src/common-ssh/common-ssh/buffer.h
@@ -76,7 +76,7 @@ void guac_common_ssh_buffer_write_string(char** buffer, const char* string,
  * @param value
  *     The value to write.
  */
-void guac_common_ssh_buffer_write_bignum(char** buffer, BIGNUM* value);
+void guac_common_ssh_buffer_write_bignum(char** buffer, const BIGNUM* value);
 
 /**
  * Writes the given data the given buffer, advancing the buffer pointer by the

--- a/src/common-ssh/common-ssh/dsa-compat.h
+++ b/src/common-ssh/common-ssh/dsa-compat.h
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef GUAC_COMMON_SSH_DSA_COMPAT_H
+#define GUAC_COMMON_SSH_DSA_COMPAT_H
+
+#include "config.h"
+
+#include <openssl/bn.h>
+#include <openssl/dsa.h>
+
+#ifndef HAVE_DSA_GET0_PQG
+/**
+ * DSA_get0_pqg() implementation for versions of OpenSSL which lack this
+ * function (pre 1.1).
+ *
+ * See: https://www.openssl.org/docs/man1.1.0/crypto/DSA_get0_pqg.html
+ */
+void DSA_get0_pqg(const DSA* dsa_key, const BIGNUM** p,
+        const BIGNUM** q, const BIGNUM** g);
+#endif
+
+#ifndef HAVE_DSA_GET0_KEY
+/**
+ * DSA_get0_key() implementation for versions of OpenSSL which lack this
+ * function (pre 1.1).
+ *
+ * See: https://www.openssl.org/docs/man1.1.0/crypto/DSA_get0_key.html
+ */
+void DSA_get0_key(const DSA* dsa_key, const BIGNUM** pub_key,
+        const BIGNUM** priv_key);
+#endif
+
+#ifndef HAVE_DSA_SIG_GET0
+/**
+ * DSA_SIG_get0() implementation for versions of OpenSSL which lack this
+ * function (pre 1.1).
+ *
+ * See: https://www.openssl.org/docs/man1.1.0/crypto/DSA_SIG_get0.html
+ */
+void DSA_SIG_get0(const DSA_SIG* dsa_sig, const BIGNUM** r, const BIGNUM** s);
+#endif
+
+#endif
+

--- a/src/common-ssh/common-ssh/rsa-compat.h
+++ b/src/common-ssh/common-ssh/rsa-compat.h
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef GUAC_COMMON_SSH_RSA_COMPAT_H
+#define GUAC_COMMON_SSH_RSA_COMPAT_H
+
+#include "config.h"
+
+#include <openssl/bn.h>
+#include <openssl/rsa.h>
+
+#ifndef HAVE_RSA_GET0_KEY
+/**
+ * RSA_get0_key() implementation for versions of OpenSSL which lack this
+ * function (pre 1.1).
+ *
+ * See: https://www.openssl.org/docs/man1.1.0/crypto/RSA_get0_key.html
+ */
+void RSA_get0_key(const RSA* rsa_key, const BIGNUM** n,
+        const BIGNUM** e, const BIGNUM**d);
+#endif
+
+#endif
+

--- a/src/common-ssh/dsa-compat.c
+++ b/src/common-ssh/dsa-compat.c
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "config.h"
+
+#include <openssl/bn.h>
+#include <openssl/dsa.h>
+
+#include <stdlib.h>
+
+#ifndef HAVE_DSA_GET0_PQG
+void DSA_get0_pqg(const DSA* dsa_key, const BIGNUM** p,
+        const BIGNUM** q, const BIGNUM** g) {
+
+    /* Retrieve all requested internal values */
+    if (p != NULL) *p = dsa_key->p;
+    if (q != NULL) *q = dsa_key->q;
+    if (g != NULL) *g = dsa_key->g;
+
+}
+#endif
+
+#ifndef HAVE_DSA_GET0_KEY
+void DSA_get0_key(const DSA* dsa_key, const BIGNUM** pub_key,
+        const BIGNUM** priv_key) {
+
+    /* Retrieve all requested internal values */
+    if (pub_key  != NULL) *pub_key  = dsa_key->pub_key;
+    if (priv_key != NULL) *priv_key = dsa_key->priv_key;
+
+}
+#endif
+
+#ifndef HAVE_DSA_SIG_GET0
+void DSA_SIG_get0(const DSA_SIG* dsa_sig, const BIGNUM** r, const BIGNUM** s) {
+
+    /* Retrieve all requested internal values */
+    if (r != NULL) *r = dsa_sig->r;
+    if (s != NULL) *s = dsa_sig->s;
+
+}
+#endif
+

--- a/src/common-ssh/key.c
+++ b/src/common-ssh/key.c
@@ -20,7 +20,9 @@
 #include "config.h"
 
 #include "common-ssh/buffer.h"
+#include "common-ssh/dsa-compat.h"
 #include "common-ssh/key.h"
+#include "common-ssh/rsa-compat.h"
 
 #include <openssl/bio.h>
 #include <openssl/bn.h>
@@ -54,6 +56,9 @@ guac_common_ssh_key* guac_common_ssh_key_alloc(char* data, int length,
 
         RSA* rsa_key;
 
+        const BIGNUM* key_e;
+        const BIGNUM* key_n;
+
         /* Read key */
         rsa_key = PEM_read_bio_RSAPrivateKey(key_bio, NULL, NULL, passphrase);
         if (rsa_key == NULL)
@@ -70,10 +75,13 @@ guac_common_ssh_key* guac_common_ssh_key_alloc(char* data, int length,
         public_key = malloc(4096);
         pos = public_key;
 
-        /* Derive public key */
+        /* Retrieve public key */
+        RSA_get0_key(rsa_key, &key_n, &key_e, NULL);
+
+        /* Send public key formatted for SSH */
         guac_common_ssh_buffer_write_string(&pos, "ssh-rsa", sizeof("ssh-rsa")-1);
-        guac_common_ssh_buffer_write_bignum(&pos, rsa_key->e);
-        guac_common_ssh_buffer_write_bignum(&pos, rsa_key->n);
+        guac_common_ssh_buffer_write_bignum(&pos, key_e);
+        guac_common_ssh_buffer_write_bignum(&pos, key_n);
 
         /* Save public key to structure */
         key->public_key = public_key;
@@ -87,6 +95,11 @@ guac_common_ssh_key* guac_common_ssh_key_alloc(char* data, int length,
                       sizeof(SSH_DSA_KEY_HEADER)-1) == 0) {
 
         DSA* dsa_key;
+
+        const BIGNUM* key_p;
+        const BIGNUM* key_q;
+        const BIGNUM* key_g;
+        const BIGNUM* pub_key;
 
         /* Read key */
         dsa_key = PEM_read_bio_DSAPrivateKey(key_bio, NULL, NULL, passphrase);
@@ -104,12 +117,16 @@ guac_common_ssh_key* guac_common_ssh_key_alloc(char* data, int length,
         public_key = malloc(4096);
         pos = public_key;
 
-        /* Derive public key */
+        /* Retrieve public key */
+        DSA_get0_pqg(dsa_key, &key_p, &key_q, &key_g);
+        DSA_get0_key(dsa_key, &pub_key, NULL);
+
+        /* Send public key formatted for SSH */
         guac_common_ssh_buffer_write_string(&pos, "ssh-dss", sizeof("ssh-dss")-1);
-        guac_common_ssh_buffer_write_bignum(&pos, dsa_key->p);
-        guac_common_ssh_buffer_write_bignum(&pos, dsa_key->q);
-        guac_common_ssh_buffer_write_bignum(&pos, dsa_key->g);
-        guac_common_ssh_buffer_write_bignum(&pos, dsa_key->pub_key);
+        guac_common_ssh_buffer_write_bignum(&pos, key_p);
+        guac_common_ssh_buffer_write_bignum(&pos, key_q);
+        guac_common_ssh_buffer_write_bignum(&pos, key_g);
+        guac_common_ssh_buffer_write_bignum(&pos, pub_key);
 
         /* Save public key to structure */
         key->public_key = public_key;
@@ -157,7 +174,6 @@ int guac_common_ssh_key_sign(guac_common_ssh_key* key, const char* data,
         int length, unsigned char* sig) {
 
     const EVP_MD* md;
-    EVP_MD_CTX md_ctx;
 
     unsigned char digest[EVP_MAX_MD_SIZE];
     unsigned int dlen, len;
@@ -166,10 +182,18 @@ int guac_common_ssh_key_sign(guac_common_ssh_key* key, const char* data,
     if ((md = EVP_get_digestbynid(NID_sha1)) == NULL)
         return -1;
 
+    /* Allocate digest context */
+    EVP_MD_CTX* md_ctx = EVP_MD_CTX_create();
+    if (md_ctx == NULL)
+        return -1;
+
     /* Digest data */
-    EVP_DigestInit(&md_ctx, md);
-    EVP_DigestUpdate(&md_ctx, data, length);
-    EVP_DigestFinal(&md_ctx, digest, &dlen);
+    EVP_DigestInit(md_ctx, md);
+    EVP_DigestUpdate(md_ctx, data, length);
+    EVP_DigestFinal(md_ctx, digest, &dlen);
+
+    /* Digest context no longer needed */
+    EVP_MD_CTX_destroy(md_ctx);
 
     /* Sign with key */
     switch (key->type) {
@@ -184,9 +208,15 @@ int guac_common_ssh_key_sign(guac_common_ssh_key* key, const char* data,
             DSA_SIG* dsa_sig = DSA_do_sign(digest, dlen, key->dsa);
             if (dsa_sig != NULL) {
 
+                const BIGNUM* sig_r;
+                const BIGNUM* sig_s;
+
+                /* Retrieve DSA signature values */
+                DSA_SIG_get0(dsa_sig, &sig_r, &sig_s);
+
                 /* Compute size of each half of signature */
-                int rlen = BN_num_bytes(dsa_sig->r);
-                int slen = BN_num_bytes(dsa_sig->s);
+                int rlen = BN_num_bytes(sig_r);
+                int slen = BN_num_bytes(sig_s);
 
                 /* Ensure each number is within the required size */
                 if (rlen > DSA_SIG_NUMBER_SIZE || slen > DSA_SIG_NUMBER_SIZE)
@@ -196,11 +226,11 @@ int guac_common_ssh_key_sign(guac_common_ssh_key* key, const char* data,
                 memset(sig, 0, DSA_SIG_SIZE);
 
                 /* Add R at the end of the first block of the signature */
-                BN_bn2bin(dsa_sig->r, sig + DSA_SIG_SIZE
-                                          - DSA_SIG_NUMBER_SIZE - rlen);
+                BN_bn2bin(sig_r, sig + DSA_SIG_SIZE
+                                     - DSA_SIG_NUMBER_SIZE - rlen);
 
                 /* Add S at the end of the second block of the signature */
-                BN_bn2bin(dsa_sig->s, sig + DSA_SIG_SIZE - slen);
+                BN_bn2bin(sig_s, sig + DSA_SIG_SIZE - slen);
 
                 /* Done */
                 DSA_SIG_free(dsa_sig);

--- a/src/common-ssh/rsa-compat.c
+++ b/src/common-ssh/rsa-compat.c
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "config.h"
+
+#include <openssl/bn.h>
+#include <openssl/rsa.h>
+
+#include <stdlib.h>
+
+#ifndef HAVE_RSA_GET0_KEY
+void RSA_get0_key(const RSA* rsa_key, const BIGNUM** n,
+        const BIGNUM** e, const BIGNUM**d) {
+
+    /* Retrieve all requested internal values */
+    if (n != NULL) *n = rsa_key->n;
+    if (e != NULL) *e = rsa_key->e;
+    if (d != NULL) *d = rsa_key->d;
+
+}
+#endif
+

--- a/src/common-ssh/ssh.c
+++ b/src/common-ssh/ssh.c
@@ -46,6 +46,7 @@
 GCRY_THREAD_OPTION_PTHREAD_IMPL;
 #endif
 
+#ifdef OPENSSL_REQUIRES_THREADING_CALLBACKS
 /**
  * Array of mutexes, used by OpenSSL.
  */
@@ -134,6 +135,7 @@ static void guac_common_ssh_openssl_free_locks(int count) {
     free(guac_common_ssh_openssl_locks);
 
 }
+#endif
 
 int guac_common_ssh_init(guac_client* client) {
 
@@ -146,10 +148,12 @@ int guac_common_ssh_init(guac_client* client) {
     }
 #endif
 
+#ifdef OPENSSL_REQUIRES_THREADING_CALLBACKS
     /* Init threadsafety in OpenSSL */
     guac_common_ssh_openssl_init_locks(CRYPTO_num_locks());
     CRYPTO_set_id_callback(guac_common_ssh_openssl_id_callback);
     CRYPTO_set_locking_callback(guac_common_ssh_openssl_locking_callback);
+#endif
 
     /* Init OpenSSL */
     SSL_library_init();
@@ -164,7 +168,9 @@ int guac_common_ssh_init(guac_client* client) {
 }
 
 void guac_common_ssh_uninit() {
+#ifdef OPENSSL_REQUIRES_THREADING_CALLBACKS
     guac_common_ssh_openssl_free_locks(CRYPTO_num_locks());
+#endif
 }
 
 /**

--- a/src/guacd/daemon.c
+++ b/src/guacd/daemon.c
@@ -154,6 +154,7 @@ static int daemonize() {
 }
 
 #ifdef ENABLE_SSL
+#ifdef OPENSSL_REQUIRES_THREADING_CALLBACKS
 /**
  * Array of mutexes, used by OpenSSL.
  */
@@ -242,6 +243,7 @@ static void guacd_openssl_free_locks(int count) {
     free(guacd_openssl_locks);
 
 }
+#endif
 #endif
 
 int main(int argc, char* argv[]) {
@@ -367,10 +369,12 @@ int main(int argc, char* argv[]) {
 
         guacd_log(GUAC_LOG_INFO, "Communication will require SSL/TLS.");
 
+#ifdef OPENSSL_REQUIRES_THREADING_CALLBACKS
         /* Init threadsafety in OpenSSL */
         guacd_openssl_init_locks(CRYPTO_num_locks());
         CRYPTO_set_id_callback(guacd_openssl_id_callback);
         CRYPTO_set_locking_callback(guacd_openssl_locking_callback);
+#endif
 
         /* Init SSL */
         SSL_library_init();
@@ -498,7 +502,9 @@ int main(int argc, char* argv[]) {
 
 #ifdef ENABLE_SSL
     if (ssl_context != NULL) {
+#ifdef OPENSSL_REQUIRES_THREADING_CALLBACKS
         guacd_openssl_free_locks(CRYPTO_num_locks());
+#endif
         SSL_CTX_free(ssl_context);
     }
 #endif


### PR DESCRIPTION
While the Glyptodon Enterprise 2.x build works fine against RHEL 8, the Glyptodon Enterprise 1.x build fails due to the use of the older OpenSSL API.