### PR TITLE
GLEN-182: Correct GCC 7 sprintf() warning resulting in GLEN 1.x build failure on RHEL 8.

### DIFF
--- a/src/terminal/typescript.c
+++ b/src/terminal/typescript.c
@@ -130,8 +130,13 @@ guac_terminal_typescript* guac_terminal_typescript_alloc(const char* path,
     }
 
     /* Append suffix to basename */
-    sprintf(typescript->timing_filename, "%s.%s", typescript->data_filename,
-            GUAC_TERMINAL_TYPESCRIPT_TIMING_SUFFIX);
+    if (snprintf(typescript->timing_filename, sizeof(typescript->timing_filename),
+                "%s.%s", typescript->data_filename, GUAC_TERMINAL_TYPESCRIPT_TIMING_SUFFIX)
+            >= sizeof(typescript->timing_filename)) {
+        close(typescript->data_fd);
+        free(typescript);
+        return NULL;
+    }
 
     /* Attempt to open typescript timing file */
     typescript->timing_fd = open(typescript->timing_filename,


### PR DESCRIPTION
A warning regarding `sprintf()` specific to GCC 7 was corrected upstream via [GUACAMOLE-500](https://issues.apache.org/jira/browse/GUACAMOLE-500) for 1.0.0 and later. As the base version of Guacamole packaged by Glyptodon Enterprise 1.x is earlier than this (0.9.12-incubating), the build fails with a warning on RHEL 8.