### PR TITLE
GLEN-171: Correct management of resources allocated during (re)connect.

### DIFF
--- a/src/protocols/rdp/channels/disp.c
+++ b/src/protocols/rdp/channels/disp.c
@@ -96,11 +96,51 @@ static void guac_rdp_disp_channel_connected(rdpContext* context,
 
 }
 
+/**
+ * Callback which disassociates Guacamole from the DispClientContext instance
+ * that was originally allocated by FreeRDP and is about to be deallocated.
+ *
+ * This function is called whenever a channel disconnects via the PubSub event
+ * system within FreeRDP, but only has any effect if the disconnected channel
+ * is the Display Update channel. This specific callback is registered with the
+ * PubSub system of the relevant rdpContext when guac_rdp_disp_load_plugin() is
+ * called.
+ *
+ * @param context
+ *     The rdpContext associated with the active RDP session.
+ *
+ * @param e
+ *     Event-specific arguments, mainly the name of the channel, and a
+ *     reference to the associated plugin loaded for that channel by FreeRDP.
+ */
+static void guac_rdp_disp_channel_disconnected(rdpContext* context,
+        ChannelDisconnectedEventArgs* e) {
+
+    guac_client* client = ((rdp_freerdp_context*) context)->client;
+    guac_rdp_client* rdp_client = (guac_rdp_client*) client->data;
+    guac_rdp_disp* guac_disp = rdp_client->disp;
+
+    /* Ignore disconnection event if it's not for the Display Update channel */
+    if (strcmp(e->name, DISP_DVC_CHANNEL_NAME) != 0)
+        return;
+
+    /* Channel is no longer connected */
+    guac_disp->disp = NULL;
+
+    guac_client_log(client, GUAC_LOG_DEBUG, "Display update channel "
+            "disconnected.");
+
+}
+
 void guac_rdp_disp_load_plugin(rdpContext* context) {
 
     /* Subscribe to and handle channel connected events */
     PubSub_SubscribeChannelConnected(context->pubSub,
         (pChannelConnectedEventHandler) guac_rdp_disp_channel_connected);
+
+    /* Subscribe to and handle channel disconnected events */
+    PubSub_SubscribeChannelDisconnected(context->pubSub,
+            (pChannelDisconnectedEventHandler) guac_rdp_disp_channel_disconnected);
 
     /* Add "disp" channel */
     guac_freerdp_dynamic_channel_collection_add(context->settings, "disp", NULL);

--- a/src/protocols/rdp/channels/rdpei.c
+++ b/src/protocols/rdp/channels/rdpei.c
@@ -94,11 +94,50 @@ static void guac_rdp_rdpei_channel_connected(rdpContext* context,
 
 }
 
+/**
+ * Callback which disassociates Guacamole from the RdpeiClientContext instance
+ * that was originally allocated by FreeRDP and is about to be deallocated.
+ *
+ * This function is called whenever a channel disconnects via the PubSub event
+ * system within FreeRDP, but only has any effect if the disconnected channel
+ * is the RDPEI channel. This specific callback is registered with the PubSub
+ * system of the relevant rdpContext when guac_rdp_rdpei_load_plugin() is
+ * called.
+ *
+ * @param context
+ *     The rdpContext associated with the active RDP session.
+ *
+ * @param e
+ *     Event-specific arguments, mainly the name of the channel, and a
+ *     reference to the associated plugin loaded for that channel by FreeRDP.
+ */
+static void guac_rdp_rdpei_channel_disconnected(rdpContext* context,
+        ChannelDisconnectedEventArgs* e) {
+
+    guac_client* client = ((rdp_freerdp_context*) context)->client;
+    guac_rdp_client* rdp_client = (guac_rdp_client*) client->data;
+    guac_rdp_rdpei* guac_rdpei = rdp_client->rdpei;
+
+    /* Ignore disconnection event if it's not for the RDPEI channel */
+    if (strcmp(e->name, RDPEI_DVC_CHANNEL_NAME) != 0)
+        return;
+
+    /* Channel is no longer connected */
+    guac_rdpei->rdpei = NULL;
+
+    guac_client_log(client, GUAC_LOG_DEBUG, "RDPDI channel disconnected.");
+
+}
+
 void guac_rdp_rdpei_load_plugin(rdpContext* context) {
 
     /* Subscribe to and handle channel connected events */
     PubSub_SubscribeChannelConnected(context->pubSub,
         (pChannelConnectedEventHandler) guac_rdp_rdpei_channel_connected);
+
+    /* Subscribe to and handle channel disconnected events */
+    PubSub_SubscribeChannelDisconnected(context->pubSub,
+            (pChannelDisconnectedEventHandler) guac_rdp_rdpei_channel_disconnected);
 
     /* Add "rdpei" channel */
     guac_freerdp_dynamic_channel_collection_add(context->settings, "rdpei", NULL);

--- a/src/protocols/rdp/rdp.c
+++ b/src/protocols/rdp/rdp.c
@@ -418,18 +418,6 @@ static int guac_rdp_handle_connection(guac_client* client) {
 
     pthread_rwlock_wrlock(&(rdp_client->lock));
 
-    /* Set up screen recording, if requested */
-    if (settings->recording_path != NULL) {
-        rdp_client->recording = guac_common_recording_create(client,
-                settings->recording_path,
-                settings->recording_name,
-                settings->create_recording_path,
-                !settings->recording_exclude_output,
-                !settings->recording_exclude_mouse,
-                !settings->recording_exclude_touch,
-                settings->recording_include_keys);
-    }
-
     /* Create display */
     rdp_client->display = guac_common_display_alloc(client,
             rdp_client->settings->width,
@@ -756,6 +744,18 @@ void* guac_rdp_client_thread(void* data) {
 
     }
 #endif
+
+    /* Set up screen recording, if requested */
+    if (settings->recording_path != NULL) {
+        rdp_client->recording = guac_common_recording_create(client,
+                settings->recording_path,
+                settings->recording_name,
+                settings->create_recording_path,
+                !settings->recording_exclude_output,
+                !settings->recording_exclude_mouse,
+                !settings->recording_exclude_touch,
+                settings->recording_include_keys);
+    }
 
     /* Continue handling connections until error or client disconnect */
     while (client->state == GUAC_CLIENT_RUNNING) {


### PR DESCRIPTION
Compared to all other supported protocols, the "Reconnect" resize method of Guacamole's RDP support uniquely requires that the underlying RDP connection be torn down and reinstated, and thus requires that associated resources are properly freed and reallocated when associated only with that session.

Current handling of those resources is incorrect:

* Pointers to channel resources from the previous RDP connection remain, resulting in assertion failures and disconnects if the features provided by those channels happen to be used before the new instances of those channels are connected.
* Session recordings are allocated within each RDP connection, rather than the single logical Guacamole connection managing those RDP connections. This results in new recordings being created for each reconnect, rather than a single continuous recording representing the overall connection.

These changes correct the above.